### PR TITLE
Remove logging from pyswitch wrapper.

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,5 +1,5 @@
 pyswitch
-=====
+========
 
 .. toctree::
    :maxdepth: 5

--- a/pyswitch/NetConfDevice.py
+++ b/pyswitch/NetConfDevice.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import sys
 import xml.etree.ElementTree as ET
@@ -225,7 +224,6 @@ class NetConfDevice(AbstractDevice):
                 ncclient.transport.SSHError,
                 ncclient.transport.AuthenticationError,
                 ncclient.transport.SSHUnknownHostError) as error:
-            logging.error(error)
             raise DeviceCommError
 
     def close(self):

--- a/pyswitch/NetConfDevice.py
+++ b/pyswitch/NetConfDevice.py
@@ -223,7 +223,7 @@ class NetConfDevice(AbstractDevice):
                 ncclient.transport.SessionCloseError,
                 ncclient.transport.SSHError,
                 ncclient.transport.AuthenticationError,
-                ncclient.transport.SSHUnknownHostError) as error:
+                ncclient.transport.SSHUnknownHostError):
             raise DeviceCommError
 
     def close(self):

--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import logging
 import re
 
 from ipaddress import ip_interface
@@ -91,8 +90,7 @@ class Interface(object):
             self._callback(config)
             return True
 
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def get_vlan_int(self, vlan_id):
@@ -107,8 +105,7 @@ class Interface(object):
             else:
                 return False
 
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def interface_exists(self, **kwargs):
@@ -158,8 +155,7 @@ class Interface(object):
             self._callback(config)
             return True
 
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def enable_switchport(self, inter_type, inter):
@@ -183,8 +179,7 @@ class Interface(object):
         try:
             self._callback(config)
             return True
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def disable_switchport(self, inter_type, inter):
@@ -208,8 +203,7 @@ class Interface(object):
         try:
             self._callback(config)
             return True
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def access_vlan(self, inter_type, inter, vlan_id):
@@ -236,8 +230,7 @@ class Interface(object):
         try:
             self._callback(config)
             return True
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def del_access_vlan(self, inter_type, inter, vlan_id):
@@ -264,9 +257,8 @@ class Interface(object):
         try:
             self._callback(config)
             return True
-        # TODO add logging and narrow exception window.
-        except Exception as error:
-            logging.error(error)
+        # TODO narrow exception window.
+        except Exception:
             return False
 
     def set_ip(self, inter_type, inter, ip_addr):
@@ -293,8 +285,7 @@ class Interface(object):
         try:
             self._callback(config)
             return True
-        except Exception as error:
-            logging.error(error)
+        except Exception:
             return False
 
     def remove_port_channel(self, **kwargs):

--- a/pyswitch/os/slxos/base/bgp.py
+++ b/pyswitch/os/slxos/base/bgp.py
@@ -1,6 +1,5 @@
-from pyswitch.os.base.bgp import Bgp as BaseBgp
-
 import pyswitch.utilities as util
+from pyswitch.os.base.bgp import Bgp as BaseBgp
 from pyswitch.utilities import Util
 
 
@@ -43,7 +42,8 @@ class Bgp(BaseBgp):
         return
 
     def evpn_afi(self, **kwargs):
-        """EVPN AFI. This method just enables/disables or gets the EVPN AFI.
+        """
+        EVPN AFI. This method just enables/disables or gets the EVPN AFI.
 
         Args:
             rbridge_id (str): The rbridge ID of the device on which BGP will be
@@ -51,8 +51,7 @@ class Bgp(BaseBgp):
             delete (bool): Deletes the neighbor if `delete` is ``True``.
             get (bool): Get config instead of editing config. (True, False)
             callback (function): A function executed upon completion of the
-                method.  The only parameter passed to `callback` will be the
-                ``ElementTree`` `config`.
+                method. The only parameter passed to `callback` will be the``ElementTree`` `config`
 
         Returns:
             Return value of `callback`.
@@ -72,6 +71,7 @@ class Bgp(BaseBgp):
             ...     output = dev.bgp.evpn_afi(rbridge_id='225',
             ...     delete=True)
         """
+
         return
 
     def evpn_afi_peer_activate(self, **kwargs):
@@ -116,6 +116,7 @@ class Bgp(BaseBgp):
             ...     output = dev.bgp.remove_bgp(rbridge_id='225')
 
         """
+
         return
 
     def evpn_afi_peergroup_encapsulation(self, **kwargs):


### PR DESCRIPTION
There is no reason to include logging in the wrapper code. The approach
would be to raise Exceptions appropriate to the api