### PR TITLE
MLX wrappers for switchport access action

### DIFF
--- a/pyswitch/snmp/SnmpMib.py
+++ b/pyswitch/snmp/SnmpMib.py
@@ -6,8 +6,8 @@ class SnmpMib:
         'dot1qVlanStaticTable': '1.3.6.1.2.1.17.7.1.4.3.1',
         'dot1qVlanStaticEntry': '1.3.6.1.2.1.17.7.1.4.3.1.1',
         'dot1qVlanStaticName': '1.3.6.1.2.1.17.7.1.4.3.1.2',
-        'dot1qVlanStaticEgressPorts': '1.3.6.1.2.1.17.7.1.4.3.1.3',
-        'dot1qVlanForbiddenEgressPorts': '1.3.6.1.2.1.17.7.1.4.3.1.4',
+        'dot1qVlanStaticEgressPorts': '1.3.6.1.2.1.17.7.1.4.3.1.2',
+        'dot1qVlanStaticUntaggedPorts': '1.3.6.1.2.1.17.7.1.4.3.1.4',
         'dot1qVlanStaticRowStatus': '1.3.6.1.2.1.17.7.1.4.3.1.5',
         'ifAdminStatus': '1.3.6.1.2.1.2.2.1.7',
         'ifAlias': '1.3.6.1.2.1.31.1.1.1.18'


### PR DESCRIPTION
Pyswitch API wrappers for switchport access vlan action
1)  create/delete a  untagged port to a vlan
2)  get a IPv4/IPv6 address of a given interface using CLI operational data