### PR TITLE
MLX-47: Add function to extract LACP port info required for NE action

### DIFF
--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -33,6 +33,9 @@ NI_VERSIONS = {
     '6.1': {
         'interface': pyswitch.snmp.mlx.base.interface.Interface,
     },
+    '6.2': {
+        'interface': pyswitch.snmp.mlx.base.interface.Interface,
+    },
 }
 
 

--- a/pyswitch/snmp/snmpconnector.py
+++ b/pyswitch/snmp/snmpconnector.py
@@ -32,6 +32,7 @@ class SnmpUtils:
 
     SNMP_DEVICE_MAP = {
         '1.3.6.1.4.1.1991.1.3.44.3.2': 'MLX',
+        '1.3.6.1.4.1.1991.1.3.55.3.2': 'MLX',
     }
 
     DEVICE_FIRMWARE_MAP = {


### PR DESCRIPTION
- Add API to extract LACP port information for dynamic LAG's. 
- Made changes in pyswitch wrapper to integrate validate_L2_port_channel_state NE action.
- SNMP Device connection was failing for 6.2 release of MLX. Triaged the issue and found that sysobjid is different for 6.2 and added the same to SNMPUtils.
- Added support for 6.2 release for interface pyswitch wrapper.
- Tested on 6.1, 6.2 of MLX and SLXOS.