### PR TITLE
Snmpv3 support

### DIFF
--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -90,6 +90,11 @@ class SnmpCliDevice(AbstractDevice):
         self._snmpversion = snmpconfig['version']
         self._snmpport = snmpconfig['snmpport']
         self._snmpv2c = snmpconfig['snmpv2c']
+        self._v3user = snmpconfig['v3user']
+        self._v3auth = snmpconfig['v3auth']
+        self._v3priv = snmpconfig['v3priv']
+        self._authpass = snmpconfig['authpass']
+        self._privpass = snmpconfig['privpass']
         self._sysobj = sysobj
 
         if self._callback is None:
@@ -284,7 +289,12 @@ class SnmpCliDevice(AbstractDevice):
         if 'snmp' not in self._mgr:
             self._mgr['snmp'] = SNMPDevice(host=self.host, port=self._snmpport,
                                            version=self._snmpversion,
-                                           community=self._snmpv2c)
+                                           community=self._snmpv2c,
+                                           username=self._v3user,
+                                           authproto=self._v3auth,
+                                           authkey=self._authpass,
+                                           privproto=self._v3priv,
+                                           privkey=self._privpass)
         if 'cli' not in self._mgr:
             #  FIXME: Revisit this logic
             opt = {'device_type': 'brocade_netiron'}

--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -69,10 +69,17 @@ class Device(object):
             snmpport = snmpconfig['snmpport']
             snmpver = snmpconfig['version']
             snmpv2c = snmpconfig['snmpv2c']
+            v3user = snmpconfig['v3user']
+            v3auth = snmpconfig['v3auth']
+            v3priv = snmpconfig['v3priv']
+            authpass = snmpconfig['authpass']
+            privpass = snmpconfig['privpass']
 
         if snmpver == 2 or snmpver == 3:
             try:
-                snmpdev = SNMPDevice(host=host, port=snmpport, version=snmpver, community=snmpv2c)
+                snmpdev = SNMPDevice(host=host, port=snmpport, version=snmpver, community=snmpv2c,
+                                     username=v3user, authproto=v3auth, authkey=authpass,
+                                     privproto=v3priv, privkey=privpass)
                 sysobj = str(snmpdev.get(MIB.mib_oid_map['sysObjectId']))
             except SNMPError:
                 """


### PR DESCRIPTION
Added SNMPv3 support for SNMP CLI device creation.  Testing was done as part of the testcases mentioned in https://github.com/StackStorm/network_essentials/pull/185
