### PR TITLE
Mlx 33 branch

### DIFF
--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -169,6 +169,44 @@ class Acl(object):
         """
         return
 
+    @abc.abstractmethod
+    def apply_acl(self, **parameters):
+        """
+        Apply Access Control List on interface.
+        Args:
+            parameters contains:
+                address_type (str): ACL address type, ip or ipv6 or mac.
+                acl_name: Name of the access list.
+                intf_type: - ethernet, ve
+                intf_name: array of slot/port or ve interfaces
+                acl_direction: Direction of ACL binding on the specified
+                    interface
+        Returns:
+            Return True
+        Raises:
+            Exception, ValueError for invalid seq_id.
+        """
+        return
+
+    @abc.abstractmethod
+    def remove_acl(self, **parameters):
+        """
+        Apply Access Control List on interface.
+        Args:
+            parameters contains:
+                address_type (str): ACL address type, ip or ipv6 or mac.
+                acl_name: Name of the access list.
+                intf_type: - ethernet, ve
+                intf_name: array of slot/port or ve interfaces
+                acl_direction: Direction of ACL binding on the specified
+                    interface
+        Returns:
+            Return True
+        Raises:
+            Exception, ValueError for invalid seq_id.
+        """
+        return
+
     def _process_cli_output(self, method, config, output):
         """
         Parses CLI response from switch.

--- a/pyswitch/snmp/base/acl/macacl.py
+++ b/pyswitch/snmp/base/acl/macacl.py
@@ -164,7 +164,8 @@ class MacAcl(object):
         parse the ethertype param
         Args:
             parameters contains:
-                ethertype(string): EtherType, can be 'arp', 'fcoe', 'ipv4-15', 'ipv6' or
+                ethertype(string): EtherType, can be 'arp',
+                    'fcoe', 'ipv4-15', 'ipv6' or
                     custom value between 1536 and 65535.
         Returns:
             Return None or parsed string on success
@@ -197,7 +198,8 @@ class MacAcl(object):
         Args:
             parameters contains:
                 arp_guard( string): Enables arp-guard for the rule
-                ethertype(string): EtherType, can be 'arp', 'fcoe', 'ipv4-15', 'ipv6' or
+                ethertype(string): EtherType, can be 'arp', 'fcoe',
+                    'ipv4-15', 'ipv6' or
                     custom value between 1536 and 65535.
         Returns:
             Return None or parsed string on success
@@ -378,9 +380,8 @@ class MacAcl(object):
         if not priority:
             return None
 
-        if priority.isdigit():
-            if int(priority) >= 0 or int(priority) <= 7:
-                return 'priority ' + priority
+        if int(priority) >= 0 or int(priority) <= 7:
+            return 'priority ' + str(priority)
 
         raise ValueError("The \'priority\' value {} is invalid."
                          " Supported range is 0 to 7".format(priority))
@@ -407,9 +408,8 @@ class MacAcl(object):
         if not priority_force:
             return None
 
-        if priority_force.isdigit():
-            if int(priority_force) >= 0 or int(priority_force) <= 7:
-                return 'priority-force ' + priority_force
+        if int(priority_force) >= 0 or int(priority_force) <= 7:
+            return 'priority-force ' + str(priority_force)
 
         raise ValueError("The \'priority_force\' value {} is invalid."
                          " Supported range is 0 to 7".format(priority_force))
@@ -436,9 +436,8 @@ class MacAcl(object):
         if not priority_mapping:
             return None
 
-        if priority_mapping.isdigit():
-            if int(priority_mapping) >= 0 or int(priority_mapping) <= 7:
-                return 'priority-mapping ' + priority_mapping
+        if int(priority_mapping) >= 0 or int(priority_mapping) <= 7:
+            return 'priority-mapping ' + str(priority_mapping)
 
         raise ValueError("The \'priority_mapping\' value {} is invalid."
                          " Supported range is 0 to 7".format(priority_mapping))

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -389,27 +389,28 @@ class Acl(BaseAcl):
 
         address_type = self.get_address_type(acl_name)
 
+        if address_type not in [ 'mac', 'ip', 'ipv6']:
+            raise ValueError('{} not supported'.format(address_type))
+
         if address_type == 'mac':
             if intf_type != 'ethernet':
                 raise ValueError('intf type:{} not supported'
                                  .format(intf_type))
 
-            for intf in intf_name:
-                cmd = acl_template.interface_submode_template
-                t = jinja2.Template(cmd)
-                config = t.render(intf_name=intf, **parameters)
-                config = ' '.join(config.split())
-                cli_arr.append(config)
+        for intf in intf_name:
+            cmd = acl_template.interface_submode_template
+            t = jinja2.Template(cmd)
+            config = t.render(intf_name=intf, **parameters)
+            config = ' '.join(config.split())
+            cli_arr.append(config)
 
-                cmd = acl_template.apply_acl_mac_template
-                t = jinja2.Template(cmd)
-                config = t.render(**parameters)
-                config = ' '.join(config.split())
-                cli_arr.append(config)
+            cmd = acl_template.apply_acl_template
+            t = jinja2.Template(cmd)
+            config = t.render(address_type=address_type, **parameters)
+            config = ' '.join(config.split())
+            cli_arr.append(config)
 
-                cli_arr.append('exit')
-        else:
-            raise ValueError('{} not supported'.format(address_type))
+            cli_arr.append('exit')
 
         output = self._callback(cli_arr, handler='cli-set')
         return self._process_cli_output(inspect.stack()[0][3], config, output)
@@ -440,32 +441,31 @@ class Acl(BaseAcl):
 
         address_type = self.get_address_type(acl_name)
 
+        if address_type not in [ 'mac', 'ip', 'ipv6']:
+            raise ValueError('{} not supported'.format(address_type))
+
         if address_type == 'mac':
             if intf_type != 'ethernet':
                 raise ValueError('intf type:{} not supported'
                                  .format(intf_type))
 
-            for intf in intf_name:
-                cmd = acl_template.interface_submode_template
-                t = jinja2.Template(cmd)
-                config = t.render(intf_name=intf, **parameters)
-                config = ' '.join(config.split())
-                cli_arr.append(config)
+        for intf in intf_name:
+            cmd = acl_template.interface_submode_template
+            t = jinja2.Template(cmd)
+            config = t.render(intf_name=intf, **parameters)
+            config = ' '.join(config.split())
+            cli_arr.append(config)
 
-                cmd = acl_template.remove_acl_mac_template
-                t = jinja2.Template(cmd)
-                config = t.render(**parameters)
-                config = ' '.join(config.split())
-                cli_arr.append(config)
+            cmd = acl_template.remove_acl_template
+            t = jinja2.Template(cmd)
+            config = t.render(address_type=address_type, **parameters)
+            config = ' '.join(config.split())
+            cli_arr.append(config)
 
-                cli_arr.append('exit')
+            cli_arr.append('exit')
 
-                output = self._callback(cli_arr, handler='cli-set')
-                self._process_cli_output(inspect.stack()[0][3], config, output)
-        else:
-            raise ValueError('{} not supported'.format(address_type))
-
-        return True
+        output = self._callback(cli_arr, handler='cli-set')
+        return self._process_cli_output(inspect.stack()[0][3], config, output)
 
     def get_address_type(self, acl_name):
         """

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -389,7 +389,7 @@ class Acl(BaseAcl):
 
         address_type = self.get_address_type(acl_name)
 
-        if address_type not in [ 'mac', 'ip', 'ipv6']:
+        if address_type not in ['mac', 'ip', 'ipv6']:
             raise ValueError('{} not supported'.format(address_type))
 
         if address_type == 'mac':
@@ -441,7 +441,7 @@ class Acl(BaseAcl):
 
         address_type = self.get_address_type(acl_name)
 
-        if address_type not in [ 'mac', 'ip', 'ipv6']:
+        if address_type not in ['mac', 'ip', 'ipv6']:
             raise ValueError('{} not supported'.format(address_type))
 
         if address_type == 'mac':

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -53,13 +53,13 @@ delete_rule_by_seq_id = '''
     '''
 
 interface_submode_template = '''
-    interface ethernet {{ intf_name }}
+    interface {{ intf_type }} {{ intf_name }}
 '''
 
-apply_acl_mac_template = '''
-    mac access-group {{ acl_name }} {{ acl_direction }}
+apply_acl_template = '''
+    {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
 '''
 
-remove_acl_mac_template = '''
-    no mac access-group {{ acl_name }} {{ acl_direction }}
+remove_acl_template = '''
+    no {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
 '''

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -51,3 +51,15 @@ add_l2_acl_rule_template = '''
 delete_rule_by_seq_id = '''
     no sequence {{ seq_id_str }}
     '''
+
+interface_submode_template = '''
+    interface ethernet {{ intf_name }}
+'''
+
+apply_acl_mac_template = '''
+    mac access-group {{ acl_name }} {{ acl_direction }}
+'''
+
+remove_acl_mac_template = '''
+    no mac access-group {{ acl_name }} {{ acl_direction }}
+'''


### PR DESCRIPTION
Added support for apply_acl and remove_acl in pyswitch lib.

Below actions were tested as part of this change.

st2 run network_essentials.apply_acl username=admin password=admin mgmt_ip=10.37.73.148 intf_type=ethernet intf_name=1/1,1/3 acl_name=ACL_IP_standard_test acl_direction=in

st2 run network_essentials.remove_acl username=admin password=admin mgmt_ip=10.37.73.148 intf_type=ethernet intf_name=1/1,1/3 acl_name=ACL_MAC_standard_test acl_direction=in

st2 run network_essentials.apply_acl username=admin password=admin mgmt_ip=10.37.73.148 intf_type=ethernet intf_name=1/1,1/3 acl_name=ACL_IP_standard_test acl_direction=in

st2 run network_essentials.remove_acl username=admin password=admin mgmt_ip=10.37.73.148 intf_type=ethernet intf_name=1/1,1/3 acl_name=ACL_IP_standard_test acl_direction=in
