### PR TITLE
MLX-33 and MLX-36:

### DIFF
--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -210,7 +210,7 @@ class Acl(object):
     @abc.abstractmethod
     def add_ipv4_rule_acl(self, **parameters):
         """
-        Apply Access Control List on interface.
+        Add rules to Access Control List of ipv4.
         Args:
             parameters contains:
                 acl_name: (string) Name of the access list
@@ -246,6 +246,28 @@ class Acl(object):
                     (Available for permit or deny only)
                 mirror: (string) Enables mirror for the rule
                 copy_sflow: (string) Enables copy-sflow for the rule
+
+                dscp-marking: (string) dscp-marking number is used to mark the
+                    DSCP value in the incoming packet with the value you
+                    specify to filter.  Allowed values are 0 through 63.
+                fragment: (string) Use fragment keyword to allow the ACL to
+                    filter fragmented packets. Use the non-fragment keyword to
+                    filter non-fragmented packets.
+                    Allowed values are- fragment, non-fragment
+                precedence: (integer) Match packets with given precedence value
+                    Allowed value in range 0 to 7.
+                option: (string) Match match IP option packets.
+                    supported values are:
+                        any, eol, extended-security, ignore, loose-source-route
+                        no-op, record-route, router-alert, security, streamid,
+                        strict-source-route, timestamp
+                        Allowed value in decimal <0-255>.
+                suppress-rpf-drop: (boolean) Permit packets that fail RPF check
+                priority: (integer) set priority
+                priority-force: (integer) force packet outgoing priority.
+                priority-mapping: (integer) map incoming packet priority.
+                tos: (integer) Match packets with given TOS value.
+                    Allowed value in decimal <0-15>.
         Returns:
             Return True
         Raises:

--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -169,6 +169,68 @@ class Acl(object):
         """
         return
 
+    @abc.abstractmethod
+    def add_ipv4_rule_acl(self, **parameters):
+        """
+        Apply Access Control List on interface.
+        Args:
+            parameters contains:
+                acl_name: (string) Name of the access list
+                seq_id: (integer) Sequence number of the rule,
+                    if not specified, the rule is added at the end of the list.
+                    Valid range is 0 to 4294967290
+                action: (string) Action performed by ACL rule
+                    - permit
+                    - deny
+                protocol_type: (string) Type of IP packets to be filtered
+                    based on protocol. Valid values are <0-255> or key words
+                    tcp, udp, icmp or ip
+                source: (string) Source address filters
+                    { any | S_IPaddress/mask(0.0.0.255) |
+                    host,S_IPaddress } [ source-operator [ S_port-numbers ] ]
+                destination: (string) Destination address filters
+                    { any | S_IPaddress/mask(0.0.0.255) |
+                    host,S_IPaddress } [ source-operator [ S_port-numbers ] ]
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+                drop_precedence_force: (string) Matches the drop_precedence
+                    value of the packet.  Allowed values are 0 through 2.
+                urg: (string) Enables urg for the rule
+                ack: (string) Enables ack for the rule
+                push: (string) Enables push for the rule
+                fin: (string) Enables fin for the rule
+                rst: (string) Enables rst for the rule
+                sync: (string) Enables sync for the rule
+                vlan_id: (integer) VLAN interface to which the ACL is bound
+                count: (string) Enables statistics for the rule
+                log: (string) Enables logging for the rule
+                    (Available for permit or deny only)
+                mirror: (string) Enables mirror for the rule
+                copy_sflow: (string) Enables copy-sflow for the rule
+        Returns:
+            Return True
+        Raises:
+            Exception, ValueError for invalid seq_id.
+        """
+        return
+
+    def delete_ipv4_acl_rule(self, **parameters):
+        """
+        Delete Rule from Access Control List.
+        Args:
+            parameters contains:
+                acl_name: Name of the access list.
+                seq_id: Sequence number of the rule. For add operation,
+                    if not specified, the rule is added at the end of the list.
+        Returns:
+            Return value of `string` message.
+        Raise:
+            Raises ValueError, Exception
+        Examples:
+        """
+        return
+
     def _process_cli_output(self, method, config, output):
         """
         Parses CLI response from switch.

--- a/pyswitch/snmp/base/acl/ipacl.py
+++ b/pyswitch/snmp/base/acl/ipacl.py
@@ -1,0 +1,513 @@
+"""
+Copyright 2017 Brocade Communications Systems, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class IpAcl(object):
+    """
+    The IpAcl class holds all the functions assocaiated with
+    IP Access Control list.
+    Attributes:
+        None
+    """
+
+    def parse_action(self, **parameters):
+        """
+        parse supported actions by MLX platform
+        Args:
+            parameters contains:
+                action (string): Allowed actions are 'permit' and 'deny'
+        Returns:
+            Return parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+
+        """
+        if 'action' not in parameters:
+            raise ValueError("\'action\' not present in parameters arg")
+
+        action = parameters['action']
+
+        if parameters['action'] in ['permit', 'deny']:
+            return parameters['action']
+
+        raise ValueError("The \'action\' value {} is invalid. Specify "
+                         "\'deny\' or \'permit\' supported "
+                         "values".format(action))
+
+    def parse_source(self, **parameters):
+        """
+        parse the source param.
+        Args:
+            parameters contains:
+                source (string): Source filter, can be 'any' or
+                    the MAC/Mask in HHHH.HHHH.HHHH/mask or
+                    the host Mask in HHHH.HHHH.HHHH or
+                    host <name | ip >
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'source' not in parameters:
+            raise ValueError("\'source\' is parameters arg")
+
+        src = parameters['source']
+        src = ' '.join(src.split()).split()
+
+        if src[0] == "any":
+            return "any"
+        elif src[0] == "host":
+            return "host " + src[1]
+        elif '/' in src[0]:
+            return src[0]
+        elif len(src) == 2:
+            return src[0] + ' ' + src[1]
+
+        raise ValueError("Invalid source {}. Supported format is "
+                         "source can be 'any' or the MAC/Mask in "
+                         "HHHH.HHHH.HHHH/mask or the host Mask in "
+                         "HHHH.HHHH.HHHH.HHHH or host <name | ip >"
+                         .format(src))
+
+    def parse_vlan(self, **parameters):
+        """
+        parse the vlan param
+        Args:
+            parameters contains:
+                vlan_id(integer): 1-4096
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'vlan_id' not in parameters:
+            return None
+
+        vlan = parameters['vlan_id']
+
+        if not vlan:
+            return None
+
+        if vlan > 0 and vlan < 4096:
+            return str(vlan)
+
+        raise ValueError("The \'vlan\' value {} is invalid."
+                         " Specify \'1-4095\' supported values")
+
+    def parse_log(self, **parameters):
+        """
+        parse the log param
+        Args:
+            parameters contains:
+                log(string): Enables the logging
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'log' in parameters:
+            if parameters['log'] == 'True':
+                return 'log'
+
+        return None
+
+    def parse_protocol(self, **parameters):
+        """
+        parse the protocol param
+        Args:
+            parameters contains:
+                protocol_type: (string) Type of IP packets to be filtered
+                    based on protocol. Valid values are <0-255> or
+                    key words tcp, udp, icmp or ip
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'protocol_type' not in parameters:
+            return None
+
+        protocol_type = parameters['protocol_type']
+
+        if not protocol_type:
+            return None
+
+        if protocol_type.isdigit():
+            if int(protocol_type) < 0 or int(protocol_type) > 255:
+                raise ValueError("The \'protocol\' value {} is invalid."
+                                 " Specify \'0-255\' supported values"
+                                 .format(protocol_type))
+
+        return str(protocol_type)
+
+    def parse_destination(self, **parameters):
+        """
+        parse the destination param.
+        Args:
+            parameters contains:
+                destination (string): destination filter, can be 'any' or
+                    the MAC/Mask in HHHH.HHHH.HHHH/mask or
+                    the host Mask in HHHH.HHHH.HHHH or
+                    host <name | ip >
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'destination' not in parameters:
+            raise ValueError("\'destination\' is mandatory parameters arg")
+
+        dst = parameters['destination']
+
+        if not dst:
+            raise ValueError("\'destination\' is mandatory parameters arg")
+
+        dst = ' '.join(dst.split()).split()
+
+        if dst[0] == "any":
+            return "any"
+        elif dst[0] == "host":
+            return "host " + dst[1]
+        elif '/' in dst[0]:
+            return dst[0]
+
+        raise ValueError("Invalid destination {}. Supported format is "
+                         "destination can be 'any' or the MAC/Mask in "
+                         "HHHH.HHHH.HHHH/mask or the host Mask in "
+                         .format(dst))
+
+    def parse_dscp_mapping(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'dscp' not in parameters:
+            return None
+
+        dscp_mapping = parameters['dscp']
+        dscp_mapping = ' '.join(dscp_mapping.split())
+
+        if dscp_mapping.isdigit():
+            if int(dscp_mapping) >= 0 and int(dscp_mapping) <= 63:
+                return 'dscp-mapping ' + dscp_mapping
+
+        raise ValueError("Invalid dscp_mapping {}. Supported range is "
+                         "<0-63>".format(dscp_mapping))
+
+    def parse_dscp_marking(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'dscp_marking' not in parameters:
+            return None
+
+        dscp_marking = parameters['dscp_marking']
+        dscp_marking = ' '.join(dscp_marking.split())
+
+        if dscp_marking.isdigit():
+            if int(dscp_marking) >= 0 and int(dscp_marking) <= 63:
+                return 'dscp-marking ' + dscp_marking
+
+        raise ValueError("Invalid dscp_marking {}. Supported range is "
+                         "<0-63>".format(dscp_marking))
+
+    def parse_fragment(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'fragment' not in parameters:
+            return None
+
+        fragment = parameters['fragment']
+        if not fragment:
+            return None
+        fragment = ' '.join(fragment.split())
+
+        if fragment in ['fragment', 'non-fragment']:
+            return fragment
+
+        raise ValueError("Invalid fragment {}. Supported values are "
+                         "fragment or non-fragment".format(fragment))
+
+    def parse_precedence(self, **parameters):
+        """
+        parse the precedence mapping param.
+        Args:
+            parameters contains:
+                precedence:
+                  type: string
+                  description: Match packets with given precedence value.
+                      Allowed value { <0 to 7> | critical | flash |
+                      flash-override | immediate | internet | network |
+                      priority | routine  }
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'precedence' not in parameters:
+            return None
+
+        precedence = parameters['precedence']
+        if not precedence:
+            return None
+        precedence = ' '.join(precedence.split())
+
+        if precedence.isdigit():
+            if int(precedence) >= 0 and int(precedence) <= 7:
+                return 'precedence ' + precedence
+        if precedence in ['critical' 'flash', 'flash-override',
+                          'immediate', 'internet', 'network',
+                          'priority', 'routine']:
+                return 'precedence ' + precedence
+
+        raise ValueError("Invalid precedence {}. Supported values are "
+                         "<0 to 7> | critical | flash |"
+                         "flash-override | immediate | internet | network |"
+                         "priority | routine ".format(precedence))
+
+    def parse_option(self, **parameters):
+        """
+        parse the option mapping param.
+        Args:
+            parameters contains:
+                option (string): Match match IP option packets.
+                    supported values are -
+                        any, eol, extended-security, ignore, loose-source-route
+                        no-op, record-route, router-alert, security, streamid,
+                        strict-source-route, timestamp
+                        Allowed value in decimal <0-255>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'option' not in parameters:
+            return None
+
+        option = parameters['option']
+        if not option:
+            return None
+        option = ' '.join(option.split())
+
+        if option.isdigit():
+            if int(option) >= 0 and int(option) <= 255:
+                return 'option ' + option
+        if option in ['any', 'eol', 'extended-security',
+                      'ignore', 'loose-source-route',
+                      'no-op', 'record-route', 'router-alert',
+                      'security', 'streamid',
+                      'strict-source-route', 'timestamp']:
+                return 'option ' + option
+
+        raise ValueError("Invalid option {}. Supported values are "
+                         "any, eol, extended-security, ignore, "
+                         "loose-source-route no-op, record-route, "
+                         "router-alert, security, streamid, "
+                         "strict-source-route, timestamp "
+                         "Allowed value in decimal <0-255>."
+                         .format(option))
+
+    def parse_suppress_rpf_drop(self, **parameters):
+        """
+        parse the suppress_rpf_drop mapping param.
+        Args:
+            parameters contains:
+                suppress_rpf_drop (boolean):Permit packets that fail RPF check
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'suppress_rpf_drop' not in parameters:
+            return None
+        suppress_rpf_drop = parameters['suppress_rpf_drop']
+        if not suppress_rpf_drop:
+            return None
+
+        return 'suppress-rpf-drop'
+
+    def parse_priority(self, **parameters):
+        """
+        parse the priority param.
+        Args:
+            parameters contains:
+                priority(integer): set priorityr. Allowed value is <0-7>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'priority' not in parameters:
+            return None
+
+        priority = parameters['priority']
+        if not priority:
+            return None
+
+        if priority >= 0 and priority <= 7:
+            return 'priority ' + str(priority)
+
+        raise ValueError("Invalid priority {}. "
+                         "Allowed value in decimal <0-7>."
+                         .format(priority))
+
+    def parse_priority_force(self, **parameters):
+        """
+        parse the priority_force mapping param.
+        Args:
+            parameters contains:
+                priority_force(integer): set priority_forcer.
+                    Allowed value is <0-7>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'priority_force' not in parameters:
+            return None
+
+        priority_force = parameters['priority_force']
+        if not priority_force:
+            return None
+
+        if priority_force >= 0 and priority_force <= 7:
+            return 'priority-force ' + str(priority_force)
+
+        raise ValueError("Invalid priority_force {}. "
+                         "Allowed value in decimal <0-7>."
+                         .format(priority_force))
+
+    def parse_priority_mapping(self, **parameters):
+        """
+        parse the priority_mapping mapping param.
+        Args:
+            parameters contains:
+                priority_mapping(integer): set priority_mappingr.
+                    Allowed value is <0-7>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'priority_mapping' not in parameters:
+            return None
+
+        priority_mapping = parameters['priority_mapping']
+        if not priority_mapping:
+            return None
+
+        if priority_mapping >= 0 and priority_mapping <= 7:
+            return 'priority-mapping ' + str(priority_mapping)
+
+        raise ValueError("Invalid priority_mapping {}. "
+                         "Allowed value in decimal <0-7>."
+                         .format(priority_mapping))
+
+    def parse_tos(self, **parameters):
+        """
+        parse the tos mapping param.
+        Args:
+            parameters contains:
+                tos(integer): set tosr. Allowed value is <0-15>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'tos' not in parameters:
+            return None
+
+        tos = parameters['tos']
+        if not tos:
+            return None
+
+        if tos >= 0 and tos <= 15:
+            return 'tos ' + str(tos)
+
+        raise ValueError("Invalid tos {}. "
+                         "Allowed value in decimal <0-15>."
+                         .format(tos))
+
+    def parse_mirror(self, **parameters):
+        """
+        parse the mirror param
+        Args:
+            parameters contains:
+                log(string): Enables the logging
+                mirror(string): Enables mirror for the rule.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'mirror' not in parameters:
+            return None
+
+        mirror = parameters['mirror']
+
+        if mirror == 'True':
+            if 'log' not in parameters:
+                return 'mirror'
+            log = parameters['log']
+            if log == 'False':
+                return 'mirror'
+        else:
+            return None
+
+        raise ValueError("The \'mirror\' value {} is invalid."
+                         " mirror can not be configured along with log"
+                         .format(mirror))

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -475,7 +475,7 @@ class Acl(BaseAcl):
 
     def add_ipv4_rule_acl(self, **parameters):
         """
-        Apply Access Control List on interface.
+        Add rules to Access Control List of ipv4.
         Args:
             parameters contains:
                 acl_name: (string) Name of the access list
@@ -511,6 +511,28 @@ class Acl(BaseAcl):
                     (Available for permit or deny only)
                 mirror: (string) Enables mirror for the rule
                 copy_sflow: (string) Enables copy-sflow for the rule
+
+                dscp-marking: (string) dscp-marking number is used to mark the
+                    DSCP value in the incoming packet with the value you
+                    specify to filter.  Allowed values are 0 through 63.
+                fragment: (string) Use fragment keyword to allow the ACL to
+                    filter fragmented packets. Use the non-fragment keyword to
+                    filter non-fragmented packets.
+                    Allowed values are- fragment, non-fragment
+                precedence: (integer) Match packets with given precedence value
+                    Allowed value in range 0 to 7.
+                option: (string) Match match IP option packets.
+                    supported values are:
+                        any, eol, extended-security, ignore, loose-source-route
+                        no-op, record-route, router-alert, security, streamid,
+                        strict-source-route, timestamp
+                        Allowed value in decimal <0-255>.
+                suppress-rpf-drop: (boolean) Permit packets that fail RPF check
+                priority: (integer) set priority
+                priority-force: (integer) force packet outgoing priority.
+                priority-mapping: (integer) map incoming packet priority.
+                tos: (integer) Match packets with given TOS value.
+                    Allowed value in decimal <0-15>.
         Returns:
             Return True
         Raises:

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -51,3 +51,40 @@ add_l2_acl_rule_template = '''
 delete_rule_by_seq_id = '''
     no sequence {{ seq_id_str }}
     '''
+
+interface_submode_template = '''
+    interface {{ intf_type }} {{ intf_name }}
+'''
+
+add_ip_standard_acl_rule_template = '''
+    {% if seq_id_str is not none %} sequence {{ seq_id_str }} {% endif %}
+    {% if action_str is not none %} {{ action_str }} {% endif %}
+    {% if vlan_str is not none %} vlan {{ vlan_str }} {% endif %}
+    {% if source_str is not none %} {{ source_str }} {% endif %}
+    {% if log_str is not none %} {{ log_str }} {% endif %}
+    '''
+
+add_ip_extended_acl_rule_template = '''
+    {% if seq_id_str is not none %} sequence {{ seq_id_str }} {% endif %}
+    {% if action_str is not none %} {{ action_str }} {% endif %}
+    {% if protocol_str is not none %} {{ protocol_str }} {% endif %}
+    {% if source_str is not none %} {{ source_str }} {% endif %}
+    {% if dst_str is not none %} {{ dst_str }} {% endif %}
+    {% if drop_precedence_force_str is not none %}
+        {{ drop_precedence_force_str }} {% endif %}
+    {% if dscp_mapping_str is not none %} {{ dscp_mapping_str }} {% endif %}
+    {% if dscp_marking_str is not none %} {{ dscp_marking_str }} {% endif %}
+    {% if fragment_str is not none %} {{ fragment_str }} {% endif %}
+    {% if precedence_str is not none %} {{ precedence_str }} {% endif %}
+    {% if option_str is not none %} {{ option_str }} {% endif %}
+    {% if suppress_rpf_drop_str is not none %}
+        {{ suppress_rpf_drop_str }} {% endif %}
+    {% if priority_str is not none %} {{ priority_str }} {% endif %}
+    {% if priority__force_str is not none %}
+        {{ priority__force_str }} {% endif %}
+    {% if priority__mapping_str is not none %}
+        {{ priority__mapping_str }} {% endif %}
+    {% if tos_str is not none %} {{ tos_str }} {% endif %}
+    {% if log_str is not none %} {{ log_str }} {% endif %}
+    {% if mirror_str is not none %} {{ mirror_str }} {% endif %}
+    '''


### PR DESCRIPTION
Added ACL APIs for adding and deleting ipv4 rule to acl.

Following test cases are executed:

* Adding rule to standard ipv4 ACL
-- st2 run network_essentials.add_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_standard_test action=permit  vlan_id=20 log=False source='1.1.0.0 0.0.255.255'
-- st2 run network_essentials.add_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_standard_test action=permit source=any

* Adding rule to extended ipv4 ACL
-- st2 run network_essentials.add_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_extended_test action=permit source=any destination=any protocol_type=iatp dscp=1 dscp_marking=5 fragment=fragment  option=33 suppress_rpf_drop=False  priority_mapping=4 tos=8 log=False mirror=True
-- st2 run network_essentials.add_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_extended_test action=permit source=any destination=any protocol_type=iatp dscp=3 dscp_marking=4 fragment=non-fragment precedence=3 option='eol' suppress_rpf_drop=True  priority_mapping=4 tos=8 log=True mirror=False

* Deleting rule ipv4 ACL using seq_id
-- st2 run network_essentials.delete_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_extended_test seq_id=60
