### PR TITLE
Pyswitch wrapper for MAC table for MLX platform. 

### DIFF
--- a/pyswitch/AbstractDevice.py
+++ b/pyswitch/AbstractDevice.py
@@ -16,10 +16,6 @@ class AbstractDevice:
     def __exit__(self, exctype, excisnt, exctb):
         pass
 
-    @abc.abstractmethod
-    def mac_table(self):
-        pass
-
     @abc.abstractproperty
     def os_type(self):
         pass
@@ -39,10 +35,6 @@ class AbstractDevice:
 
     @abc.abstractmethod
     def reconnect(self):
-        pass
-
-    @abc.abstractmethod
-    def find_interface_by_mac(self, **kwargs):
         pass
 
     @abc.abstractmethod

--- a/pyswitch/NetConfDevice.py
+++ b/pyswitch/NetConfDevice.py
@@ -15,7 +15,6 @@ import pyswitch.raw.nos.base.interface
 import pyswitch.raw.slxos.base.interface
 import pyswitch.utilities as util
 from pyswitch.AbstractDevice import AbstractDevice
-from pyswitch.utilities import Util
 
 NOS_ATTRS = ['snmp', 'interface', 'bgp', 'lldp', 'system', 'services',
              'fabric_service', 'vcs', 'acl']
@@ -263,57 +262,6 @@ class NetConfDevice(AbstractDevice):
             False
         """
         return self._mgr.close_session()
-
-    def find_interface_by_mac(self, **kwargs):
-        """Find the interface through which a MAC can be reached.
-        Args:
-            mac_address (str): A MAC address in 'xx:xx:xx:xx:xx:xx' format.
-        Returns:
-            list[dict]: a list of mac table data.
-        Raises:
-            KeyError: if `mac_address` is not specified.
-        Examples:
-            >>> from pprint import pprint
-            >>> import pyswitch.device
-            >>> conn = ('10.24.39.211', '22')
-            >>> auth = ('admin', 'password')
-            >>> with pyswitch.device.Device(conn=conn, auth=auth) as dev:
-            ...     x = dev.find_interface_by_mac(
-            ...     mac_address='10:23:45:67:89:ab')
-            ...     pprint(x) # doctest: +ELLIPSIS
-            [{'interface'...'mac_address'...'state'...'type'...'vlan'...}]
-        """
-        mac = kwargs.pop('mac_address')
-        results = [x for x in self.mac_table if x['mac_address'] == mac]
-        return results
-
-    @property
-    def mac_table(self):
-        """list[dict]: the MAC table of the device.
-
-        """
-        table = []
-
-        config = '<get-mac-address-table xmlns="urn:brocade.com:mgmt:brocade-mac-address-table' \
-                 '"></get-mac-address-table>'
-        rest_root = self._callback(config, handler='get')
-
-        util = Util(rest_root)
-        for entry in util.findlist(util.root, './/mac-address-table'):
-            address = util.find(entry, './/mac-address')
-            vlan = util.find(entry, './/vlanid')
-            mac_type = util.find(entry, './/mac-type')
-            state = util.find(entry, './/mac-state')
-            interface = util.findNode(entry, './/forwarding-interface')
-            interface_type = util.find(interface, './/interface-type')
-            interface_name = util.find(interface, './/interface-name')
-            interface = '%s%s' % (interface_type, interface_name)
-
-            table.append(dict(mac_address=address, interface=interface,
-                              state=state, vlan=vlan,
-                              type=mac_type))
-
-        return table
 
     @property
     def os_type(self):

--- a/pyswitch/RestDevice.py
+++ b/pyswitch/RestDevice.py
@@ -38,7 +38,6 @@ import pyswitch.os.slxos.base.cluster
 import pyswitch.utilities as util
 from pyswitch.AbstractDevice import AbstractDevice
 from pyswitch.XMLAsset import XMLAsset
-from pyswitch.utilities import Util
 
 NOS_ATTRS = ['snmp', 'interface', 'bgp', 'lldp', 'system', 'services',
              'fabric_service', 'vcs', 'isis', 'ospf', 'mpls', 'mct', 'firmware', 'cluster']
@@ -253,39 +252,6 @@ class RestDevice(AbstractDevice):
             return False
 
     @property
-    def mac_table(self):
-        """list[dict]: the MAC table of the device.
-         Examples:
-            >>> import pyswitch.device
-            >>> switches = ['10.24.39.231']
-            >>> auth = ('admin', 'password')
-            >>> for switch in switches:
-            ...     conn = (switch, '22')
-            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
-            ...         output = dev.mac_table
-        """
-        table = []
-
-        config = ('get_mac_address_table_rpc', {})
-        rest_root = self._callback(config, handler='get')
-        util = Util(rest_root.data)
-        for entry in util.findlist(util.root, './/mac-address-table'):
-            address = util.find(entry, './/mac-address')
-            vlan = util.find(entry, './/vlanid')
-            mac_type = util.find(entry, './/mac-type')
-            state = util.find(entry, './/mac-state')
-            interface = util.findNode(entry, './/forwarding-interface')
-            interface_type = util.find(interface, './/interface-type')
-            interface_name = util.find(interface, './/interface-name')
-            interface = '%s%s' % (interface_type, interface_name)
-
-            table.append(dict(mac_address=address, interface=interface,
-                              state=state, vlan=vlan,
-                              type=mac_type))
-
-        return table
-
-    @property
     def os_type(self):
         if self.os_type_val is None:
             self.os_type_val = self._mgr.get_os_type()
@@ -386,29 +352,6 @@ class RestDevice(AbstractDevice):
 
         self._mgr = XMLAsset(ip_addr=self._conn[0], auth=self._auth)
         return True
-
-    def find_interface_by_mac(self, **kwargs):
-        """Find the interface through which a MAC can be reached.
-        Args:
-            mac_address (str): A MAC address in 'xx:xx:xx:xx:xx:xx' format.
-        Returns:
-            list[dict]: a list of mac table data.
-        Raises:
-            KeyError: if `mac_address` is not specified.
-        Examples:
-            >>> from pprint import pprint
-            >>> import pyswitch.device
-            >>> conn = ('10.24.39.231', '22')
-            >>> auth = ('admin', 'password')
-            >>> with pyswitch.device.Device(conn=conn, auth=auth) as dev:
-            ...     x = dev.find_interface_by_mac(
-            ...     mac_address='10:23:45:67:89:ab')
-            ...     pprint(x) # doctest: +ELLIPSIS
-            [{'interface'...'mac_address'...'state'...'type'...'vlan'...}]
-        """
-        mac = kwargs.pop('mac_address')
-        results = [x for x in self.mac_table if x['mac_address'] == mac]
-        return results
 
     def close(self):
         """Close REST session.

--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -109,10 +109,6 @@ class Device(object):
         return self.device_type._mgr
 
     @property
-    def mac_table(self):
-        return self.device_type.mac_table
-
-    @property
     def os_type(self):
         return self.device_type.os_type
 

--- a/pyswitch/os/base/services.py
+++ b/pyswitch/os/base/services.py
@@ -77,3 +77,59 @@ class Services(object):
                             }
             result.append(item_results)
         return result
+
+    @property
+    def mac_table(self):
+        """list[dict]: the MAC table of the device.
+         Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.39.231']
+            >>> auth = ('admin', 'password')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.mac_table
+        """
+        table = []
+
+        config = ('get_mac_address_table_rpc', {})
+        rest_root = self._callback(config, handler='get')
+        util = Util(rest_root.data)
+        for entry in util.findlist(util.root, './/mac-address-table'):
+            address = util.find(entry, './/mac-address')
+            vlan = util.find(entry, './/vlanid')
+            mac_type = util.find(entry, './/mac-type')
+            state = util.find(entry, './/mac-state')
+            interface = util.findNode(entry, './/forwarding-interface')
+            interface_type = util.find(interface, './/interface-type')
+            interface_name = util.find(interface, './/interface-name')
+            interface = '%s%s' % (interface_type, interface_name)
+
+            table.append(dict(mac_address=address, interface_type=interface_type,
+                              interface_name=interface_name, interface=interface,
+                              state=state, vlan=vlan, type=mac_type))
+
+        return table
+
+    def find_interface_by_mac(self, **kwargs):
+        """Find the interface through which a MAC can be reached.
+        Args:
+            mac_address (str): A MAC address in 'xx:xx:xx:xx:xx:xx' format.
+        Returns:
+            list[dict]: a list of mac table data.
+        Raises:
+            KeyError: if `mac_address` is not specified.
+        Examples:
+            >>> from pprint import pprint
+            >>> import pyswitch.device
+            >>> conn = ('10.24.39.231', '22')
+            >>> auth = ('admin', 'password')
+            >>> with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...     x = dev.find_interface_by_mac(
+            ...     mac_address='10:23:45:67:89:ab')
+            ...     pprint(x) # doctest: +ELLIPSIS
+            [{'interface'...'mac_address'...'state'...'type'...'vlan'...}]
+        """
+        mac = kwargs.pop('mac_address')
+        results = [x for x in self.mac_table if x['mac_address'] == mac]
+        return results

--- a/pyswitch/snmp/SnmpMib.py
+++ b/pyswitch/snmp/SnmpMib.py
@@ -40,4 +40,8 @@ class SnmpMib:
         'ipNetToPhysicalType': '1.3.6.1.2.1.4.35.1.6',
         'ipNetToPhysicalState': '1.3.6.1.2.1.4.35.1.7',
         'ipNetToPhysicalRowStatus': '1.3.6.1.2.1.4.35.1.8',
+        'dot1qTpFdbTable': '1.3.6.1.2.1.17.7.1.2.2',
+        'dot1qTpFdbEntry': '1.3.6.1.2.1.17.7.1.2.2.1',
+        'dot1qTpFdbPort': '1.3.6.1.2.1.17.7.1.2.2.2',
+        'dot1qTpFdbStatus': '1.3.6.1.2.1.17.7.1.2.2.3',
     }


### PR DESCRIPTION
- Pyswitch wrapper for fetching mac address table for MLX
- Cleanup mac_table from Rest and NetConf devices and move it to services class under pyswitch wrapper
Related PR:
https://github.com/StackStorm/network_essentials/pull/195

Test logs on MLX and SLX:
================
ubuntu@st2vagrant:~$ st2 run network_essentials.find_mac mgmt_ip='10.24.85.107' macs='0211.3333.4444' username='admin' password='admin'
.....
id: 5a028728c4da5f41a43d54e2
status: succeeded
parameters: 
  macs:
  - 0211.3333.4444
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
  - interface: ethernet4/1
    interface_name: 4/1
    interface_type: ethernet
    mac_address: 02:11:33:33:44:44
    state: active
    type: static
    vlan: '402'
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.FindMAC: INFO     successfully connected to 10.24.85.107 to find mac address

    st2.actions.python.FindMAC: INFO     mac_address 02:11:33:33:44:44 found

    st2.actions.python.FindMAC: INFO     Closing connection to 10.24.85.107 after searching MACs -- all done!

    '
  stdout: ''

ubuntu@st2vagrant:~$ st2 run network_essentials.find_mac mgmt_ip='10.24.81.183' macs='aaaa.2222.3333' username='admin' password='password'
......
id: 5a028745c4da5f41a43d54e5
status: succeeded
parameters: 
  macs:
  - aaaa.2222.3333
  mgmt_ip: 10.24.81.183
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
  - interface: ethernet0/1
    interface_name: 0/1
    interface_type: ethernet
    mac_address: aa:aa:22:22:33:33
    state: active
    type: static
    vlan: '100'
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.FindMAC: INFO     successfully connected to 10.24.81.183 to find mac address

    st2.actions.python.FindMAC: INFO     mac_address aa:aa:22:22:33:33 found

    st2.actions.python.FindMAC: INFO     Closing connection to 10.24.81.183 after searching MACs -- all done!

    '
  stdout: ''

