### PR TITLE
Mlx 34 63 Ipv6 ACL implementation

### DIFF
--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -291,6 +291,68 @@ class Acl(object):
         """
         return
 
+    @abc.abstractmethod
+    def add_ipv6_rule_acl(self, **parameters):
+        """
+        Add rules to Access Control List of ipv6.
+        Args:
+            parameters contains:
+                acl_name(string): Name of the access list
+                seq_id(integer): Sequence number of the rule,
+                    if not specified, the rule is added
+                    at the end of the list. Valid range is 0 to 4294967290
+                action(string): Action performed by ACL rule
+                    - permit (default)
+                    - deny
+                    - hard-drop
+                protocol_type(string): Type of IP packets to be filtered based
+                    on protocol. Valid values are 0 through 255 or key words
+                    tcp, udp, icmp or ip
+                source(string): Source address filters
+                    { any | S_IPaddress mask | host S_IPaddress }
+                        [ source-operator [ S_port-numbers ] ]
+                destination(string):Destination address filters
+                    { any | S_IPaddress mask | host S_IPaddress }
+                        [ source-operator [ S_port-numbers ] ]
+                dscp(string): Matches the specified value against the DSCP
+                    value of the packet to filter.
+                    Can be either a numerical value or DSCP name
+                drop_precedence_force(string): Matches the drop_precedence
+                    value of the packet.  Allowed values are 0 through 2.
+                urg(string): Enables urg for the rule
+                ack(string): Enables ack for the rule
+                push(string): Enables push for the rule
+                fin(string): Enables fin for the rule
+                rst(string): Enables rst for the rule
+                sync(string): Enables sync for the rule
+                vlan_id:(integer): VLAN interface to which the ACL is bound
+                count(string): Enables statistics for the rule
+                log(string): Enables logging for the rule (Available for permit or deny only).
+                mirror(string): Enables mirror for the rule
+                copy_sflow(string): Enables copy-sflow for the rule
+        Returns:
+            Return True
+        Raises:
+            Exception, ValueError for invalid seq_id.
+        """
+        return
+
+    def delete_ipv6_acl_rule(self, **parameters):
+        """
+        Delete Rule from Access Control List.
+        Args:
+            parameters contains:
+                acl_name: Name of the access list.
+                seq_id: Sequence number of the rule. For add operation,
+                    if not specified, the rule is added at the end of the list.
+        Returns:
+            Return value of `string` message.
+        Raise:
+            Raises ValueError, Exception
+        Examples:
+        """
+        return
+
     def _process_cli_output(self, method, config, output):
         """
         Parses CLI response from switch.

--- a/pyswitch/snmp/base/acl/ipv6acl.py
+++ b/pyswitch/snmp/base/acl/ipv6acl.py
@@ -1,0 +1,618 @@
+"""
+Copyright 2017 Brocade Communications Systems, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import socket
+
+
+class Ipv6Acl(object):
+    """
+    The Ipv6Acl class holds all the functions assocaiated with
+    IPv6 Access Control list.
+    Attributes:
+        None
+    """
+
+    def parse_action(self, **parameters):
+        """
+        parse supported actions by MLX platform
+        Args:
+            parameters contains:
+                action (string): Allowed actions are 'permit' and 'deny'
+        Returns:
+            Return parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+
+        """
+        if 'action' not in parameters or not parameters['action']:
+            raise ValueError("\'action\' not present in parameters arg")
+
+        if parameters['action'] in ['permit', 'deny']:
+            return parameters['action']
+
+        raise ValueError("The \'action\' value {} is invalid. Specify "
+                         "\'deny\' or \'permit\' supported "
+                         "values".format(parameters['action']))
+
+    def parse_vlan(self, **parameters):
+        """
+        parse the vlan param
+        Args:
+            parameters contains:
+                vlan_id(integer): 1-4096
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'vlan_id' not in parameters:
+            return None
+
+        vlan = parameters['vlan_id']
+
+        if not vlan:
+            return None
+
+        if vlan > 0 and vlan < 4096:
+            return 'vlan ' + str(vlan)
+
+        raise ValueError("The \'vlan\' value {} is invalid."
+                         " Specify \'1-4095\' supported values")
+
+    def parse_protocol(self, **parameters):
+        """
+        parse the protocol param
+        Args:
+            parameters contains:
+                protocol_type: (string) Type of IP packets to be filtered
+                    based on protocol. Valid values are <0-255> or
+                    key words tcp, udp, icmp or ip
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type']:
+            raise ValueError("\'protocol_type\' is required for MLX device")
+
+        protocol_type = parameters['protocol_type']
+
+        if protocol_type.isdigit():
+            if int(protocol_type) < 0 or int(protocol_type) > 255:
+                raise ValueError("The \'protocol\' value {} is invalid."
+                                 " Specify \'0-255\' supported values"
+                                 .format(protocol_type))
+
+        if protocol_type in ['ahp', 'esp', 'icmp', 'ipv6',
+                             'sctp', 'tcp', 'udp']:
+            return str(protocol_type)
+
+        raise ValueError("The \'protocol\' value {} is invalid. Specify one "
+                         "of these - ahp, esp, icmp, ipv6, sctp, tcp, udp"
+                         .format(protocol_type))
+
+    def _validate_ipv6(self, addr):
+        addr = ' '.join(addr.split())
+        try:
+            socket.inet_pton(socket.AF_INET6, addr)
+        except socket.error as se:
+            raise ValueError(str(se) + 'Invalid address: ' + addr)
+
+    def _validate_op_str(self, op_str):
+        op_str = ' '.join(op_str.split()).split()
+
+        if len(op_str) == 2:
+            if (op_str[0] == 'neq' or op_str[0] == 'lt' or
+                op_str[0] == 'gt' or op_str[0] == 'eq') and \
+                    op_str[1].isdigit():
+                return True
+        elif len(op_str) == 3 and op_str[0] == 'range':
+            return True
+
+        raise ValueError('Invalid tcp-udp-operator: ' + ' '.join(op_str))
+
+    def _parse_source_destination(self, protocol_type, input_param):
+
+        v6_str = input_param
+        op_str = ''
+        op_index = -1
+        for tcp_udp_op in ['range', 'neq', 'lt', 'gt', 'eq']:
+            op_index = input_param.find(tcp_udp_op)
+            if op_index >= 0:
+                op_str = input_param[op_index:]
+                v6_str = input_param[0:op_index]
+                break
+
+        if protocol_type not in ['tcp', 'udp'] and op_str:
+            raise ValueError("tcp udp operator is supported only for."
+                             "protocol_type = tcp or udp")
+
+        if op_str:
+            self._validate_op_str(op_str)
+
+        if v6_str[0:3] == "any":
+            return v6_str + ' ' + op_str
+
+        if v6_str[0:4] == "host":
+            self._validate_ipv6(v6_str[5:])
+            return v6_str + ' ' + op_str
+
+        if '/' in v6_str:
+            self._validate_ipv6(v6_str.split('/')[0])
+            return v6_str + ' ' + op_str
+
+        ip, mask = v6_str.split()
+        self._validate_ipv6(ip)
+        self._validate_ipv6(mask)
+        return v6_str + ' ' + op_str
+
+    def parse_source(self, **parameters):
+        """
+        parse the source param.
+        Args:
+            parameters contains:
+                source (string): Source filter, can be of below format
+                    Len=1 or 3  X:X::X:X/M IPv6 source prefix (2:2::2:2/64)
+                    Len=1 or 3  any Any source host (any)
+                    Len=2 or 4  IPv6 source address (2:2::2:2 0:0::FFFF:FFFF)
+                    Len=2 or 4  host A single source host (host 2:2::2:2)
+                    followed by [ source-operator [ S_port-numbers ] ]
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'source' not in parameters or not parameters['source']:
+            raise ValueError("Missing \'source\' is parameters")
+
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type']:
+            raise ValueError("\'protocol_type\' is required for MLX device")
+
+        src = parameters['source']
+        src = ' '.join(src.split())
+
+        return self._parse_source_destination(parameters['protocol_type'], src)
+
+    def parse_destination(self, **parameters):
+        """
+        parse the destination param.
+        Args:
+            parameters contains:
+                destination (string): destination filter, can be of format:
+                    X:X::X:X/M IPv6 destination prefix (2:2::2:2/64)
+                    any Any destination host (any)
+                    IPv6 destination address (2:2::2:2 0:0::FFFF:FFFF)
+                    host A single destination host (host 2:2::2:2)
+                        followed by [ destination-operator [ S_port-numbers ] ]
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'destination' not in parameters or not parameters['destination']:
+            raise ValueError("Missing \'destination\' is parameters")
+
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type']:
+            raise ValueError("\'protocol_type\' is required for MLX device")
+
+        dst = parameters['destination']
+        dst = ' '.join(dst.split())
+
+        return self._parse_source_destination(parameters['protocol_type'], dst)
+
+    def parse_dscp_mapping(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'dscp' not in parameters:
+            return None
+
+        if not parameters['dscp']:
+            return None
+
+        dscp_mapping = parameters['dscp']
+        dscp_mapping = ' '.join(dscp_mapping.split())
+
+        if dscp_mapping.isdigit():
+            if int(dscp_mapping) >= 0 and int(dscp_mapping) <= 63:
+                return 'dscp ' + dscp_mapping
+
+        raise ValueError("Invalid dscp_mapping {}. Supported range is "
+                         "<0-63>".format(dscp_mapping))
+
+    def parse_fragment(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'fragment' not in parameters:
+            return None
+
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type']:
+            raise ValueError("\'protocol_type\' is required for MLX device")
+
+        if parameters['fragment']:
+            if parameters['protocol_type'] != 'ipv6':
+                raise ValueError("\'fragment\' can be set for ipv6 only.")
+            return 'fragments'
+
+        return None
+
+    def parse_copy_sflow(self, **parameters):
+        """
+        parse the copy_sflow mapping param.
+        Args:
+            parameters contains:
+                copy_sflow: (string) Enables copy-sflow for the rule
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'copy_sflow' not in parameters:
+            return None
+
+        if parameters['copy_sflow']:
+            return 'copy_sflow'
+
+        return None
+
+    def parse_drop_precedence(self, **parameters):
+        """
+        parse the drop_precedence param
+        Args:
+            parameters contains:
+                drop_precedence( string): Matches the specified value
+                    against the drop_precedence value of the packet to
+                    filter.  Allowed values are 0 through 3.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'drop_precedence' not in parameters:
+            return None
+
+        if not parameters['drop_precedence']:
+            return None
+
+        drop_precedence = parameters['drop_precedence']
+
+        if drop_precedence.isdigit():
+            if int(drop_precedence) >= 0 or int(drop_precedence) <= 3:
+                    return 'drop-precedence ' + drop_precedence
+
+        raise ValueError("The \'drop-precedence\' value {} is invalid."
+                         " Supported range is 0 to 3".format(drop_precedence))
+
+    def parse_drop_precedence_force(self, **parameters):
+        """
+        parse the drop_precedence_force param
+        Args:
+            parameters contains:
+                drop_precedence_force( string): Matches the specified value
+                    against the drop_precedence_force value of the packet to
+                    filter.  Allowed values are 0 through 3.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'drop_precedence_force' not in parameters:
+            return None
+
+        if not parameters['drop_precedence_force']:
+            return None
+
+        drop_precedence_force = parameters['drop_precedence_force']
+
+        if drop_precedence_force.isdigit():
+            if int(drop_precedence_force) >= 0 or \
+               int(drop_precedence_force) <= 3:
+                return 'drop-precedence-force ' + drop_precedence_force
+
+        raise ValueError("The \'drop-precedence-force\' value {} is invalid."
+                         " Supported range is 0 to 3"
+                         .format(drop_precedence_force))
+
+    def parse_dscp_marking(self, **parameters):
+        """
+        parse the dscp mapping param.
+        Args:
+            parameters contains:
+                dscp: (string) Matches the specified value against the DSCP
+                    value of the packet to filter.
+                     Allowed values are 0 through 63.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'dscp_marking' not in parameters:
+            return None
+
+        if not parameters['dscp_marking']:
+            return None
+
+        dscp_marking = parameters['dscp_marking']
+        dscp_marking = ' '.join(dscp_marking.split())
+
+        if dscp_marking.isdigit():
+            if int(dscp_marking) >= 0 and int(dscp_marking) <= 63:
+                return 'dscp-marking ' + dscp_marking
+
+        raise ValueError("Invalid dscp_marking {}. Supported range is "
+                         "<0-63>".format(dscp_marking))
+
+    def parse_priority_force(self, **parameters):
+        """
+        parse the priority_force mapping param.
+        Args:
+            parameters contains:
+                priority_force(integer): set priority_forcer.
+                    Allowed value is <0-7>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'priority_force' not in parameters:
+            return None
+
+        priority_force = parameters['priority_force']
+        if not priority_force:
+            return None
+
+        if priority_force >= 0 and priority_force <= 7:
+            return 'priority-force ' + str(priority_force)
+
+        raise ValueError("Invalid priority_force {}. "
+                         "Allowed value in decimal <0-7>."
+                         .format(priority_force))
+
+    def parse_priority_mapping(self, **parameters):
+        """
+        parse the priority_mapping mapping param.
+        Args:
+            parameters contains:
+                priority_mapping(integer): set priority_mappingr.
+                    Allowed value is <0-7>.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'priority_mapping' not in parameters:
+            return None
+
+        priority_mapping = parameters['priority_mapping']
+        if not priority_mapping:
+            return None
+
+        if priority_mapping >= 0 and priority_mapping <= 7:
+            return 'priority-mapping ' + str(priority_mapping)
+
+        raise ValueError("Invalid priority_mapping {}. "
+                         "Allowed value in decimal <0-7>."
+                         .format(priority_mapping))
+
+    def parse_suppress_rpf_drop(self, **parameters):
+        """
+        parse the suppress_rpf_drop mapping param.
+        Args:
+            parameters contains:
+                suppress_rpf_drop (boolean):Permit packets that fail RPF check
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'suppress_rpf_drop' not in parameters:
+            return None
+        suppress_rpf_drop = parameters['suppress_rpf_drop']
+        if not suppress_rpf_drop:
+            return None
+
+        return 'suppress-rpf-drop'
+
+    def parse_mirror(self, **parameters):
+        """
+        parse the mirror param
+        Args:
+            parameters contains:
+                log(string): Enables the logging
+                mirror(string): Enables mirror for the rule.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'mirror' in parameters:
+            if parameters['mirror'] == 'True':
+                return 'mirror'
+
+        return None
+
+    def parse_log(self, **parameters):
+        """
+        parse the log param
+        Args:
+            parameters contains:
+                log(string): Enables the logging
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'log' in parameters:
+            if parameters['log'] == 'True':
+                return 'log'
+
+        return None
+
+    def parse_icmp_filter(self, **parameters):
+        """
+        parse the icmp_type and icmp_code param
+        Args:
+            parameters contains:
+                icmp_filter(string): The string contains vlaues in below format
+                [ [icmp-type <vlaue>] [icmp-code <value> ] ] |
+                [ icmp-message <value> ]
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+
+        if 'icmp_filter' not in parameters or not parameters['icmp_filter']:
+            return None
+
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type'] or \
+                parameters['protocol_type'] != 'icmp':
+
+            raise ValueError("icmp filter is supported only for."
+                             "protocol_type = icmp")
+
+        icmp_filter = parameters['icmp_filter']
+        icmp_filter = ' '.join(icmp_filter.split()).split()
+
+        if icmp_filter[0].isdigit():
+            return self._parse_icmp_type_and_code(*icmp_filter)
+        else:
+            return self._parse_icmp_message(*icmp_filter)
+
+    def _parse_icmp_type_and_code(self, icmp_type, icmp_code=None):
+        """
+        parse the icmp_type and icmp_code param
+        Args:
+            icmp_type(integer): Validate an ICMP type.
+            icmp_code(integer): Validate an ICMP code.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        ret = None
+
+        if int(icmp_type) >= 0 and int(icmp_type) <= 255:
+            ret = icmp_type
+
+            if icmp_code:
+                if int(icmp_code) >= 0 and int(icmp_code) <= 255:
+                    ret = ret + ' ' + icmp_code
+
+        return ret
+
+    def _parse_icmp_message(self, icmp_message):
+        """
+        parse the icmp_message param
+        Args:
+            icmp_message(string): Validate an ICMP message.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+
+        if icmp_message in ['beyond-scope', 'destination-unreachable',
+                            'dscp', 'echo-reply', 'echo-request',
+                            'flow-label', 'fragments', 'header',
+                            'hop-limit', 'mld-query', 'mld-reduction',
+                            'mld-report', 'nd-na', 'nd-ns',
+                            'next-header', 'no-admin', 'no-route',
+                            'packet-too-big', 'parameter-option',
+                            'parameter-problem', 'port-unreachable',
+                            'reassembly-timeout', 'renum-command',
+                            'renum-result', 'renum-seq-number',
+                            'router-advertisement',
+                            'router-renumbering',
+                            'router-solicitation', 'routing',
+                            'sequence', 'time-exceeded',
+                            'unreachable']:
+            return icmp_message
+        raise ValueError("{} icmp message not supported."
+                         "Refer config guide for supported messages"
+                         .format(icmp_message))
+
+    def parse_tcp_operator(self, **parameters):
+        """
+        parse the icmp_message param
+        Args:
+            parameters contains:
+                tcp_operator(string): Validate comparison operator for TCP port
+                    This parameter works only for tcp protocol.
+                    Allowed values are : established or syn
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'tcp_operator' in parameters and parameters['tcp_operator']:
+            tcp_operator = parameters['tcp_operator']
+
+            if 'protocol_type' not in parameters or \
+                    not parameters['protocol_type'] or \
+                    parameters['protocol_type'] != 'tcp':
+
+                raise ValueError("{} tcp operator is supported only for."
+                                 "protocol_type = tcp"
+                                 .format(tcp_operator))
+
+            if tcp_operator in ['established', 'syn']:
+                return tcp_operator
+
+            raise ValueError("Only supported tcp operator are: "
+                             "established or syn")
+        return None

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -365,7 +365,7 @@ class Acl(BaseAcl):
         config = t.render(acl_name_str=acl_name)
         config = ' '.join(config.split())
 
-        output = self._callback([config], handler='cli-set')
+        output = self._callback(config, handler='cli-get')
 
         # Check if there is any error
         self._process_cli_output(inspect.stack()[0][3], config, output)
@@ -985,9 +985,10 @@ class Acl(BaseAcl):
         """
 
         ret = {'type': '', 'protocol': ''}
-        res = self._callback(['show access-list all',
-                              'show ipv6 access-list'],
-                             handler='cli-set').split('\n')
+        res = self._callback('show access-list all',
+                             handler='cli-get').split('\n')
+        res += self._callback('show ipv6 access-list',
+                              handler='cli-get').split('\n')
 
         for line in res:
             if acl_name in line:

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -843,7 +843,6 @@ class Acl(BaseAcl):
         config = ' '.join(config.split())
         cli_arr.append(config)
 
-        print cli_arr
         output = self._callback(cli_arr, handler='cli-set')
         return self._process_cli_output(inspect.stack()[0][3], config, output)
 

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -18,6 +18,7 @@ import acl_template
 from pyswitch.snmp.base.acl.acl import Acl as BaseAcl
 from pyswitch.snmp.base.acl.macacl import MacAcl
 from pyswitch.snmp.base.acl.ipacl import IpAcl
+from pyswitch.snmp.base.acl.ipv6acl import Ipv6Acl
 
 
 class Acl(BaseAcl):
@@ -42,6 +43,7 @@ class Acl(BaseAcl):
 
         self._mac = MacAcl()
         self._ip = IpAcl()
+        self._ipv6 = Ipv6Acl()
 
     @property
     def mac(self):
@@ -50,6 +52,10 @@ class Acl(BaseAcl):
     @property
     def ip(self):
         return self._ip
+
+    @property
+    def ipv6(self):
+        return self._ipv6
 
     def create_acl(self, **parameters):
         """
@@ -350,6 +356,8 @@ class Acl(BaseAcl):
             cmd = acl_template.show_l2_access_list
         elif address_type == 'ip':
             cmd = acl_template.show_ip_access_list
+        elif address_type == 'ipv6':
+            cmd = acl_template.show_ipv6_access_list
         else:
             raise ValueError('{} not supported'.format(address_type))
 
@@ -368,6 +376,7 @@ class Acl(BaseAcl):
                 continue
 
             line_seq_id = line.split(':')[0]
+            line_seq_id = ' '.join(line_seq_id.split())
             if not line_seq_id.isdigit():
                 continue
 
@@ -715,9 +724,9 @@ class Acl(BaseAcl):
         user_data['suppress_rpf_drop_str'] = \
             self.ip.parse_suppress_rpf_drop(**parameters)
         user_data['priority_str'] = self.ip.parse_priority(**parameters)
-        user_data['priority__force_str'] = \
+        user_data['priority_force_str'] = \
             self.ip.parse_priority_force(**parameters)
-        user_data['priority__mapping_str'] = \
+        user_data['priority_mapping_str'] = \
             self.ip.parse_priority_mapping(**parameters)
         user_data['tos_str'] = self.ip.parse_tos(**parameters)
         user_data['log_str'] = self.ip.parse_log(**parameters)
@@ -763,6 +772,162 @@ class Acl(BaseAcl):
         self.is_valid_seq_id(seq_id, acl_name)
 
         cli_arr = ['ip access-list ' + ' ' + acl_type + ' ' + acl_name]
+
+        cmd = acl_template.delete_rule_by_seq_id
+        t = jinja2.Template(cmd)
+        config = t.render(seq_id_str=parameters['seq_id'])
+        config = re.sub(r'[^a-zA-Z0-9 .-]', r'', config)
+        config = ' '.join(config.split())
+        cli_arr.append(config)
+
+        output = self._callback(cli_arr, handler='cli-set')
+        return self._process_cli_output(inspect.stack()[0][3], config, output)
+
+    def add_ipv6_rule_acl(self, **parameters):
+        """
+        Add rules to Access Control List of ipv6.
+        Args:
+            parameters contains:
+                acl_name(string): Name of the access list
+                seq_id(integer): Sequence number of the rule,
+                    if not specified, the rule is added
+                    at the end of the list. Valid range is 0 to 4294967290
+                action(string): Action performed by ACL rule
+                    - permit (default)
+                    - deny
+                protocol_type(string): Type of IP packets to be filtered based
+                    on protocol. Valid values are 0 through 255 or key words
+                    ahp, esp, icmp, ipv6, sctp, tcp, udp
+                source(string): Source address filters
+                    { any | S_IPaddress mask | host S_IPaddress }
+                        [ source-operator [ S_port-numbers ] ]
+                destination(string):Destination address filters
+                    { any | S_IPaddress mask | host S_IPaddress }
+                        [ source-operator [ S_port-numbers ] ]
+                dscp(string): Matches the specified value against the DSCP
+                    value of the packet to filter.
+                    Can be either a numerical value or DSCP name
+                drop_precedence_force(string): Matches the drop_precedence
+                    value of the packet.  Allowed values are 0 through 2.
+                urg(string): Enables urg for the rule
+                ack(string): Enables ack for the rule
+                push(string): Enables push for the rule
+                fin(string): Enables fin for the rule
+                rst(string): Enables rst for the rule
+                sync(string): Enables sync for the rule
+                vlan_id:(integer): VLAN interface to which the ACL is bound
+                count(string): Enables statistics for the rule
+                log(string): Enables logging for the rule
+                mirror(string): Enables mirror for the rule
+                copy_sflow(string): Enables copy-sflow for the rule
+        Returns:
+            Return True
+        Raises:
+            Exception, ValueError for invalid seq_id.
+        """
+
+        acl_name = parameters['acl_name']
+        ret = self.get_acl_address_and_acl_type(acl_name)
+        address_type = ret['protocol']
+
+        if address_type != 'ipv6':
+            raise ValueError('{} not supported'.format(address_type))
+
+        cli_arr = ['ipv6 access-list ' + ' ' + acl_name]
+
+        user_data = self.parse_params_for_add_ipv6_extended(**parameters)
+        cmd = acl_template.add_ipv6_standard_acl_rule_template
+
+        t = jinja2.Template(cmd)
+        config = t.render(**user_data)
+        config = ' '.join(config.split())
+        cli_arr.append(config)
+
+        print cli_arr
+        output = self._callback(cli_arr, handler='cli-set')
+        return self._process_cli_output(inspect.stack()[0][3], config, output)
+
+    def parse_params_for_add_ipv6_extended(self, **parameters):
+        """
+        Parase parameters passed to add_ipv6_rule_acl method.
+        Args:
+            parameters contains:
+                all parameters passed to add_ipv6_rule_acl
+        Returns:
+            Return a dict cotaining the parameters in string format
+            key name will be key name in the parameter followed by _str.
+        Raise:
+            Raises ValueError, Exception
+        """
+        user_data = {}
+        user_data['acl_name_str'] = parameters['acl_name']
+        user_data['seq_id_str'] = parameters['seq_id']
+        user_data['action_str'] = self.ipv6.parse_action(**parameters)
+        user_data['vlan_str'] = self.ipv6.parse_vlan(**parameters)
+        user_data['protocol_str'] = self.ipv6.parse_protocol(**parameters)
+        user_data['source_str'] = self.ipv6.parse_source(**parameters)
+        user_data['dst_str'] = self.ipv6.parse_destination(**parameters)
+        user_data['dscp_mapping_str'] = \
+            self.ipv6.parse_dscp_mapping(**parameters)
+        user_data['fragment_str'] = self.ipv6.parse_fragment(**parameters)
+        user_data['tcp_operator_str'] = \
+            self.ipv6.parse_tcp_operator(**parameters)
+        user_data['icmp_filter_str'] = \
+            self.ipv6.parse_icmp_filter(**parameters)
+        user_data['copy_sflow_str'] = self.ipv6.parse_copy_sflow(**parameters)
+        user_data['drop_precedence_str'] = \
+            self.ipv6.parse_drop_precedence(**parameters)
+        user_data['drop_precedence_force_str'] = \
+            self.ipv6.parse_drop_precedence_force(**parameters)
+        user_data['dscp_marking_str'] = \
+            self.ipv6.parse_dscp_marking(**parameters)
+        user_data['priority_force_str'] = \
+            self.ipv6.parse_priority_force(**parameters)
+        user_data['priority_mapping_str'] = \
+            self.ipv6.parse_priority_mapping(**parameters)
+        user_data['suppress_rpf_drop_str'] = \
+            self.ipv6.parse_suppress_rpf_drop(**parameters)
+        user_data['mirror_str'] = self.ipv6.parse_mirror(**parameters)
+        user_data['log_str'] = self.ipv6.parse_log(**parameters)
+        return user_data
+
+    def delete_ipv6_acl_rule(self, **parameters):
+        """
+        Delete Rule from Access Control List.
+        Args:
+            parameters contains:
+                acl_name: Name of the access list.
+                seq_id: Sequence number of the rule. For add operation,
+                    if not specified, the rule is added at the end of the list.
+        Returns:
+            Return value of `string` message.
+        Raise:
+            Raises ValueError, Exception
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> conn=('10.37.73.148', 22)
+            >>> auth=('admin', 'admin')
+            >>> with Device(conn=conn, auth=auth,
+            ...             connection_type='NETCONF') as dev:
+            ...     print dev.firmware_version
+            ...     print dev.os_type
+            ...     print dev.acl.create_acl(acl_name='Acl_1',
+            ...                              acl_type='extended',
+            ...                              address_type='ipv6')
+            ...     print dev.acl.add_ipv6_rule_acl(acl_name='Acl_1',
+            ...                                   action='permit',
+            ...                                   source='any',
+            ...                                   dst='any',
+            ...                                   vlan=10)
+            ...     print dev.acl.delete_ipv6_acl_rule(acl_name='Acl_1',
+            ...                                   seq_id=10)
+        """
+
+        acl_name = parameters['acl_name']
+        seq_id = parameters['seq_id']
+        self.is_valid_seq_id(seq_id, acl_name)
+
+        cli_arr = ['ipv6 access-list ' + ' ' + acl_name]
 
         cmd = acl_template.delete_rule_by_seq_id
         t = jinja2.Template(cmd)
@@ -838,7 +1003,7 @@ class Acl(BaseAcl):
                         ret['type'] = 'standard'
                 elif line[0:5] == 'ipv6 ':
                     ret['protocol'] = 'ipv6'
-                    ret['type'] = 'extended'
+                    ret['type'] = 'standard'
                 break
 
         if ret['protocol'] != '':

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -57,11 +57,19 @@ interface_submode_template = '''
 '''
 
 apply_acl_template = '''
-    {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
+    {% if 'ipv6' == address_type %}
+        {{ address_type }} traffic-filter {{ acl_name }} {{ acl_direction }}
+    {% else %}
+        {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
+    {% endif %}
 '''
 
 remove_acl_template = '''
-    no {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
+    {% if 'ipv6' == address_type %}
+        no {{ address_type }} traffic-filter {{ acl_name }} {{ acl_direction }}
+    {% else %}
+        no {{ address_type }} access-group {{ acl_name }} {{ acl_direction }}
+    {% endif %}
 '''
 
 add_ip_standard_acl_rule_template = '''

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -23,6 +23,9 @@ show_ip_access_list = '''
     show access-list name {{ acl_name_str }}
     '''
 
+show_ipv6_access_list = '''
+    show ipv6 access-list {{ acl_name_str }}
+    '''
 show_l2_access_list = '''
     show access-list l2 {{ acl_name_str }}
     '''
@@ -96,11 +99,38 @@ add_ip_extended_acl_rule_template = '''
     {% if suppress_rpf_drop_str is not none %}
         {{ suppress_rpf_drop_str }} {% endif %}
     {% if priority_str is not none %} {{ priority_str }} {% endif %}
-    {% if priority__force_str is not none %}
-        {{ priority__force_str }} {% endif %}
-    {% if priority__mapping_str is not none %}
-        {{ priority__mapping_str }} {% endif %}
+    {% if priority_force_str is not none %}
+        {{ priority_force_str }} {% endif %}
+    {% if priority_mapping_str is not none %}
+        {{ priority_mapping_str }} {% endif %}
     {% if tos_str is not none %} {{ tos_str }} {% endif %}
     {% if log_str is not none %} {{ log_str }} {% endif %}
     {% if mirror_str is not none %} {{ mirror_str }} {% endif %}
+    '''
+
+add_ipv6_standard_acl_rule_template = '''
+    {% if seq_id_str is not none %} sequence {{ seq_id_str }} {% endif %}
+    {% if action_str is not none %} {{ action_str }} {% endif %}
+    {% if vlan_str is not none %} {{ vlan_str }} {% endif %}
+    {% if protocol_str is not none %} {{ protocol_str }} {% endif %}
+    {% if source_str is not none %} {{ source_str }} {% endif %}
+    {% if dst_str is not none %} {{ dst_str }} {% endif %}
+    {% if dscp_mapping_str is not none %} {{ dscp_mapping_str }} {% endif %}
+    {% if fragment_str is not none %} {{ fragment_str }} {% endif %}
+    {% if icmp_filter_str is not none %} {{ icmp_filter_str }} {% endif %}
+    {% if tcp_operator_str is not none %} {{ tcp_operator_str }} {% endif %}
+    {% if copy_sflow_str is not none %} {{ copy_sflow_str }} {% endif %}
+    {% if drop_precedence_str is not none %}
+        {{ drop_precedence_str }} {% endif %}
+    {% if drop_precedence_force_str is not none %}
+        {{ drop_precedence_force_str }} {% endif %}
+    {% if dscp_marking_str is not none %} {{ dscp_marking_str }} {% endif %}
+    {% if priority_force_str is not none %}
+        {{ priority_force_str }} {% endif %}
+    {% if priority_mapping_str is not none %}
+        {{ priority_mapping_str }} {% endif %}
+    {% if suppress_rpf_drop_str is not none %}
+        {{ suppress_rpf_drop_str }} {% endif %}
+    {% if mirror_str is not none %} {{ mirror_str }} {% endif %}
+    {% if log_str is not none %} {{ log_str }} {% endif %}
     '''


### PR DESCRIPTION
Added APIs to pyswitch plugin of MLX to add Ipv6 rules to Ipv6 ACLs.
Following actions are tested successfully.

  # CREATE_ACL
    1. st2 run network_essentials.create_acl username=admin    password=admin  mgmt_ip=10.37.73.148            acl_name=ACL_IPv6_test    acl_type=standard       address_type=ipv6
  # DELETE_ACL
    1. st2 run network_essentials.delete_acl username=admin    password=admin  mgmt_ip=10.37.73.148            acl_name=ACL_IPv6_test

  # APPLY_ACL TO PORT
    1. st2 run network_essentials.apply_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IPv6_test intf_type=ethernet intf_name=1/1,1/2,1/3,1/5 acl_direction=in

  # REMOVE_ACL FROM PORT
    1. st2 run network_essentials.remove_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_MAC_standard_test intf_type=ethernet intf_name=1/1 acl_direction=out

  # ADD_IPV6_RULE_ACL
    1. st2 run network_essentials.add_ipv6_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IPv6_test    action=permit protocol_type=icmp source='any' destination='3001::1 2001::1 ' drop_precedence=3 copy_sflow=True icmp_filter='mld-query'
    2. st2 run network_essentials.add_ipv6_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IPv6_test    action=permit protocol_type=tcp source='any' destination='any' tcp_operator='syn'

  # DELETE_IPV6_RULE_ACL
    1. st2 run network_essentials.delete_ipv6_rule_acl username=admin password=admin mgmt_ip=10.37.73.148 acl_name=ACL_IPv6_test seq_id=20
