### PR TITLE
Pyswitch API for getting a vlan->ports mapping, port-vlan validation

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -7252,7 +7252,18 @@ class Interface(object):
             False - if mapping doesn't exist
         Raises:
             KeyError - If input args vlan_list, int_name are not passed
-        """
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.81.183']
+            >>> auth = ('admin', 'password')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],
+            ...         intf_type='ethernet', intf_name='0/1', int_mode='access')
+            ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],
+            ...         intf_type='port_channel', intf_name='10', int_mode='trunk')
+ """
         vlan_list = kwargs.pop('vlan_list')
         intf_name = kwargs.pop('intf_name')
         intf_type = kwargs.pop('intf_type')

--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -7239,3 +7239,47 @@ class Interface(object):
         """ Check if router interface config is required for VLAN
         """
         return False
+
+    def validate_interface_vlan(self, **kwargs):
+        """ Check if interface vlan(s) mapping exist
+        Args:
+           vlan_list(str): List of VLAN's
+           intf_type(str): interface type
+           intf_name(str): interface name e.g 0/1, 2/1/1, 1, 2
+           int_mode (str): access/trunk
+        Returns:
+            True - if mapping of port->vlans exist
+            False - if mapping doesn't exist
+        Raises:
+            KeyError - If input args vlan_list, int_name are not passed
+        """
+        vlan_list = kwargs.pop('vlan_list')
+        intf_name = kwargs.pop('intf_name')
+        intf_type = kwargs.pop('intf_type')
+        intf_mode = kwargs.pop('intf_mode', None)
+        if intf_type == 'port_channel':
+            # remap the intf type for port-channel
+            intf_type = 'port-channel'
+        swp_list = self.switchport_list
+        all_true = True
+        for vlan_id in vlan_list:
+            is_vlan_interface_present = False
+            is_intf_name_present = False
+            for out in swp_list:
+                for vid in out['vlan-id']:
+                    if str(vlan_id) == str(vid):
+                        is_vlan_interface_present = True
+                        if intf_name == out['interface-name'] and \
+                                intf_type == out['interface_type']:
+                            is_intf_name_present = True
+                            if intf_mode in out['mode']:
+                                continue
+                            else:
+                                all_true = False
+                        else:
+                            continue
+            if not is_vlan_interface_present:
+                all_true = False
+            if is_vlan_interface_present and not is_intf_name_present:
+                all_true = False
+        return all_true

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1880,6 +1880,14 @@ class Interface(BaseInterface):
             None
         Returns:
             List of VLANs
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.85.107']
+            >>> auth = ('admin', 'admin')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.interface.get_vlans
         """
         vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
         config = {}
@@ -1902,6 +1910,14 @@ class Interface(BaseInterface):
             None
         Returns:
             List of dictionary of vlan->port mappings
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.85.107']
+            >>> auth = ('admin', 'admin')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.interface.get_vlan_port_map
         """
         vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
         config = {}
@@ -1917,6 +1933,8 @@ class Interface(BaseInterface):
             # extract ports from each slot
             slot_octet = 1
             list = []
+            # In SNMP output each slot occupies 6 octets (48 bits) accomodating 48 ports
+            # Max slots is 32 and total octets is 192
             for i in range(0, 192, 6):
                 slot_octet = key_oid[i: 6 + i]
                 list.append(slot_octet)
@@ -1953,6 +1971,17 @@ class Interface(BaseInterface):
         Raises:
             KeyError - If input args vlan_list, int_name are not passed
             ValueError - invalid intf type
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.85.107']
+            >>> auth = ('admin', 'admin')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],
+            ...         intf_type='ethernet', intf_name='2/1')
+            ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],
+            ...         intf_type='port_channel', intf_name='10')
         """
         vlan_list = kwargs.pop('vlan_list')
         intf_name = kwargs.pop('intf_name')

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1883,10 +1883,16 @@ class Interface(BaseInterface):
         Examples:
             >>> import pyswitch.device
             >>> switches = ['10.24.85.107']
-            >>> auth = ('admin', 'admin')
+            >>> auth_snmp = ('admin', 'admin', None,
+            >>>              {'version': 2,
+            >>>               'snmpport': 161,
+            >>>               'snmpv2c': 'public',
+            >>>               'v3user':'',
+            >>>               'v3priv':'', 'v3auth':'',
+            >>>               'authpass':'', 'privpass':''})
             >>> for switch in switches:
             ...     conn = (switch, '22')
-            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...     with pyswitch.device.Device(conn=conn, auth_snmp=auth_snmp) as dev:
             ...         output = dev.interface.get_vlans
         """
         vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
@@ -1913,10 +1919,16 @@ class Interface(BaseInterface):
         Examples:
             >>> import pyswitch.device
             >>> switches = ['10.24.85.107']
-            >>> auth = ('admin', 'admin')
+            >>> auth_snmp = ('admin', 'admin', None,
+            >>>              {'version': 2,
+            >>>               'snmpport': 161,
+            >>>               'snmpv2c': 'public',
+            >>>               'v3user':'',
+            >>>               'v3priv':'', 'v3auth':'',
+            >>>               'authpass':'', 'privpass':''})
             >>> for switch in switches:
             ...     conn = (switch, '22')
-            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...     with pyswitch.device.Device(conn=conn, auth_snmp=auth_snmp) as dev:
             ...         output = dev.interface.get_vlan_port_map
         """
         vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
@@ -1974,10 +1986,16 @@ class Interface(BaseInterface):
         Examples:
             >>> import pyswitch.device
             >>> switches = ['10.24.85.107']
-            >>> auth = ('admin', 'admin')
+            >>> auth_snmp = ('admin', 'admin', None,
+            >>>              {'version': 2,
+            >>>               'snmpport': 161,
+            >>>               'snmpv2c': 'public',
+            >>>               'v3user':'',
+            >>>               'v3priv':'', 'v3auth':'',
+            >>>               'authpass':'', 'privpass':''})
             >>> for switch in switches:
             ...     conn = (switch, '22')
-            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...     with pyswitch.device.Device(conn=conn, auth_snmp=auth_snmp) as dev:
             ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],
             ...         intf_type='ethernet', intf_name='2/1')
             ...         output = dev.interface.validate_interface_vlan(vlan_list=[100,200],

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1872,3 +1872,126 @@ class Interface(BaseInterface):
         """ Check if router interface config is required for VLAN
         """
         return True
+
+    @property
+    def get_vlans(self):
+        """ Get the list of VLAN configured
+        Args:
+            None
+        Returns:
+            List of VLANs
+        """
+        vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
+        config = {}
+        config['oid'] = vlan_oid
+        config['columns'] = {5: 'row_status'}
+        config['fetch_all'] = False
+        list = []
+        vlan_table = self._callback(config, handler='snmp-walk')
+        for row in vlan_table.rows:
+            vlan = row['_row_id']
+            list.append(vlan)
+        return list
+
+    @property
+    def get_vlan_port_map(self):
+        """ Get the list of ports associated with vlan
+            Each element in the list is a dict containing vlan and list of interfaces
+            [{'vlan':10, 'interfaces':[1/1, 2/1]}, {'vlan': 20, 'interfaces':[4/1]}]
+        Args:
+            None
+        Returns:
+            List of dictionary of vlan->port mappings
+        """
+        vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
+        config = {}
+        config['oid'] = vlan_oid
+        config['columns'] = {2: 'ports'}
+        config['fetch_all'] = False
+        vlan_table = self._callback(config, handler='snmp-walk')
+        vlan_list = []
+        for row in vlan_table.rows:
+            key = row['_row_id']
+            ports = row['ports']
+            key_oid = [hex(ord(c)) for c in ports]
+            # extract ports from each slot
+            slot_octet = 1
+            list = []
+            for i in range(0, 192, 6):
+                slot_octet = key_oid[i: 6 + i]
+                list.append(slot_octet)
+            slot_num = 1
+            port_list = []
+            j = 0
+            for slot in list:
+                k = 0
+                for octet in slot:
+                    x = int(octet, 16)
+                    for i in range(8):
+                        if (x & (1 << i) != 0):
+                            port = k + 8 - i
+                            int_name = str(slot_num) + '/' + str(port)
+                            port_list.append(int_name)
+                    k = k + 8
+                    j += 1
+                slot_num += 1
+            vlan = {'vlan': key,
+                    'interfaces': port_list}
+            vlan_list.append(vlan)
+        return vlan_list
+
+    def validate_interface_vlan(self, **kwargs):
+        """ Check if interface vlan(s) mapping exist
+        Args:
+           vlan_list(str): List of VLAN's
+           intf_type(str): interface type
+           intf_name(str): interface name e.g 0/1, 2/1/1, 1, 2
+           int_mode (str): intf mode. Not applicable for MLX
+        Returns:
+            True - if mapping of port->vlans exist
+            False - if mapping doesn't exist
+        Raises:
+            KeyError - If input args vlan_list, int_name are not passed
+            ValueError - invalid intf type
+        """
+        vlan_list = kwargs.pop('vlan_list')
+        intf_name = kwargs.pop('intf_name')
+        intf_type = kwargs.pop('intf_type')
+        # intf_mode = kwargs.pop('intf_mode', None)
+        all_true = True
+        if not (intf_type == 'ethernet' or intf_type == 'port_channel'):
+            raise ValueError('Invalid interface type for MLX')
+        if intf_type == 'port_channel':
+            lag_name = self.get_lag_id_name_map(str(intf_name))
+            # get the member ports of LAG
+            ifid_name = self.get_port_channel_member_ports(lag_name)
+            # pick a member of port-channel
+            if ifid_name:
+                intf = ifid_name[next(iter(ifid_name))]
+                intf_name = intf.strip('ethernet')
+            else:
+                # Port-channel doesn't have any member ports
+                return False
+        vlan_port = self.get_vlan_port_map
+        for vlan_id in vlan_list:
+            is_vlan_present = False
+            is_intf_name_present = False
+            for entry in vlan_port:
+                if str(entry['vlan']) == str(vlan_id):
+                    is_vlan_present = True
+                    if intf_name in entry['interfaces']:
+                        is_intf_name_present = True
+                        break
+                    else:
+                        is_intf_name_present = False
+                        break
+                else:
+                    continue
+            # Given vlan is not matching with any vlan->port mapping
+            if not is_vlan_present:
+                all_true = False
+                break
+            if is_vlan_present and not is_intf_name_present:
+                all_true = False
+                break
+        return all_true


### PR DESCRIPTION
1. Pyswitch API for getting a vlan->ports mapping for MLX
2. API to retrieve all VLAN's in system for MLX
3. API to validate if a vlan->port mapping exists on system for MLX. 
4. Also, moved the validation of port-vlan mapping to pyswitch from NE action for NOS/SLX. 
5. Fixed existing issue for SLX/NOS when vlan-range or multiple vlans are provided for validation.

**Test results:**

ubuntu@st2vagrant:~$ st2 run network_essentials.validate_interface_vlan mgmt_ip='10.24.85.102' intf_name='1/0/2' intf_type='tengigabitethernet' intf_mode=trunk vlan_id='15,30'
...
id: 5a06544ec4da5f41a43d5617
status: succeeded
parameters: 
  intf_mode: trunk
  intf_name: 1/0/2
  intf_type: tengigabitethernet
  mgmt_ip: 10.24.85.102
  vlan_id: 15,30
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.24.85.102 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.24.85.102 after Validating interface vlan -- all done!

    '
ubuntu@st2vagrant:~$ st2 run network_essentials.validate_interface_vlan mgmt_ip='10.24.85.102' intf_name='1/0/2' intf_type='tengigabitethernet' intf_mode=trunk vlan_id='10-16'
....
id: 5a06542cc4da5f41a43d5611
status: succeeded
parameters: 
  intf_mode: trunk
  intf_name: 1/0/2
  intf_type: tengigabitethernet
  mgmt_ip: 10.24.85.102
  vlan_id: 10-16
result: 
  exit_code: 0
  result:
    vlan: false
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.24.85.102 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.24.85.102 after Validating interface vlan -- all done!

    '
ubuntu@st2vagrant:~$ st2 run network_essentials.validate_interface_vlan mgmt_ip='10.24.85.102' intf_name='5' intf_type='port_channel' intf_mode=trunk vlan_id='30'
...
id: 5a065a0cc4da5f41a43d561a
status: succeeded
parameters: 
  intf_mode: trunk
  intf_name: '5'
  intf_type: port_channel
  mgmt_ip: 10.24.85.102
  vlan_id: '30'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.102.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.24.85.102 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.24.85.102 after Validating interface vlan -- all done!


 ubuntu@st2vagrant:~$ st2 run network_essentials.validate_interface_vlan mgmt_ip='10.24.85.107' intf_type='ethernet' intf_name='2/1'  vlan_id='20,21' username='admin' password='admin'
....
id: 5a065a48c4da5f41a43d561d
status: succeeded
parameters: 
  intf_name: 2/1
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vlan_id: 20,21
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.24.85.107 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.24.85.107 after Validating interface vlan -- all done!


