### PR TITLE
Mac move for MLX

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -2042,3 +2042,16 @@ class Interface(BaseInterface):
                 all_true = False
                 break
         return all_true
+
+    def mac_move_detect_enable(self, **kwargs):
+        """Enable mac move detect. Not supported on MLX platform
+        Args:
+            get (bool): Get config instead of editing config. (True, False)
+            delete (bool): True - delete mac move detection
+                           False - Enable mac move detection
+        Returns:
+            error
+        Raises:
+            NotImplementedError
+        """
+        raise NotImplementedError("Not supported for MLX platform")


### PR DESCRIPTION
MAC move detect enable is not supported for MLX, handle the changes in pyswitch

Logs:

ubuntu@st2vagrant:~$ st2 run network_essentials.configure_mac_move_detection mgmt_ip='10.24.85.107' username='admin' password='admin' move_threshold=10
....
id: 5a0bc940c4da5f07cc7fdb40
status: failed
parameters: 
  mgmt_ip: 10.24.85.107
  move_threshold: 10
  password: '********'
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ConfigureMacMoveDetection: INFO     successfully connected to 10.24.85.107

    st2.actions.python.ConfigureMacMoveDetection: ERROR    Mac move enable failed Not supported for MLX platform

    '
  stdout: ''
