### PR TITLE
Added icmp filter support for ip acl type.

### DIFF
--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -327,7 +327,7 @@ class Acl(object):
                 sync(string): Enables sync for the rule
                 vlan_id:(integer): VLAN interface to which the ACL is bound
                 count(string): Enables statistics for the rule
-                log(string): Enables logging for the rule (Available for permit or deny only).
+                log(string): Enables logging for the rule
                 mirror(string): Enables mirror for the rule
                 copy_sflow(string): Enables copy-sflow for the rule
         Returns:

--- a/pyswitch/snmp/base/acl/ipacl.py
+++ b/pyswitch/snmp/base/acl/ipacl.py
@@ -682,3 +682,99 @@ class IpAcl(object):
                 return 'drop-precedence-force ' + drop_precedence_force
 
         raise ValueError("drop-precedence-force value should be 0 - 3")
+
+    def _parse_icmp_type_and_code(self, icmp_type, icmp_code=None):
+        """
+        parse the icmp_type and icmp_code param
+        Args:
+            icmp_type(integer): Validate an ICMP type.
+            icmp_code(integer): Validate an ICMP code.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        ret = None
+
+        if int(icmp_type) >= 0 and int(icmp_type) <= 255:
+            ret = icmp_type
+
+            if icmp_code:
+                if int(icmp_code) >= 0 and int(icmp_code) <= 255:
+                    ret = ret + ' ' + icmp_code
+
+        return ret
+
+    def _parse_icmp_message(self, icmp_message):
+        """
+        parse the icmp_message param
+        Args:
+            icmp_message(string): Validate an ICMP message.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+
+        if icmp_message in ['administratively-prohibited', 'any-icmp-type',
+                            'destination-host-prohibited',
+                            'destination-host-unknown',
+                            'destination-net-prohibited',
+                            'destination-network-unknown', 'echo',
+                            'echo-reply', 'general-parameter-problem',
+                            'host-precedence-violation', 'host-redirect',
+                            'host-tos-redirec', 'host-tos-unreachable',
+                            'host-unreachable', 'information-reply',
+                            'information-request', 'mask-reply',
+                            'mask-request', 'net-redirect', 'net-tos-redirect',
+                            'net-tos-unreachable', 'net-unreachable',
+                            'packet-too-big', 'parameter-problem',
+                            'port-unreachable', 'precedence-cutoff',
+                            'protocol-unreachable', 'reassembly-timeout',
+                            'redirect', 'router-advertisement',
+                            'router-solicitation', 'source-host-isolated',
+                            'source-quench', 'source-route-failed',
+                            'time-exceeded', 'timestamp-reply',
+                            'timestamp-request', 'ttl-exceeded',
+                            'unreachable']:
+            return icmp_message
+        raise ValueError("{} icmp message not supported."
+                         "Refer config guide for supported messages"
+                         .format(icmp_message))
+
+    def parse_icmp_filter(self, **parameters):
+        """
+        parse the icmp_type and icmp_code param
+        Args:
+            parameters contains:
+                icmp_filter(string): The string contains vlaues in below format
+                [ [icmp-type <vlaue>] [icmp-code <value> ] ] |
+                [ icmp-message <value> ]
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+
+        if 'icmp_filter' not in parameters or not parameters['icmp_filter']:
+            return None
+
+        if 'protocol_type' not in parameters or \
+                not parameters['protocol_type'] or \
+                parameters['protocol_type'] != 'icmp':
+
+            raise ValueError("icmp filter is supported only for."
+                             "protocol_type = icmp")
+
+        icmp_filter = parameters['icmp_filter']
+        icmp_filter = ' '.join(icmp_filter.split()).split()
+
+        if icmp_filter[0].isdigit():
+            return self._parse_icmp_type_and_code(*icmp_filter)
+        elif len(icmp_filter) == 1:
+            return self._parse_icmp_message(icmp_filter[0])
+
+        raise ValueError("invalid icmp filter string")

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -597,6 +597,9 @@ class Acl(BaseAcl):
         if 'Failed to initialize dns request' in output:
             raise ValueError('ACL DNS: Errno(5) Failed '
                              'to initialize dns request')
+        if 'are undefined' in output:
+            raise ValueError('Invlaid icmp filter: {}'
+                             .format(parameters['icmp_filter']))
         return self._process_cli_output(inspect.stack()[0][3], config, output)
 
     def parse_params_for_add_ipv4_standard(self, **parameters):
@@ -714,6 +717,8 @@ class Acl(BaseAcl):
         user_data['source_str'] = self.ip.parse_source(**parameters)
         user_data['dst_str'] = self.ip.parse_destination(**parameters)
         user_data['established_str'] = self.ip.parse_established(**parameters)
+        user_data['icmp_filter_str'] = \
+            self.ip.parse_icmp_filter(**parameters)
         user_data['dscp_mapping_str'] = \
             self.ip.parse_dscp_mapping(**parameters)
         user_data['dscp_marking_str'] = \

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -90,6 +90,7 @@ add_ip_extended_acl_rule_template = '''
     {% if source_str is not none %} {{ source_str }} {% endif %}
     {% if dst_str is not none %} {{ dst_str }} {% endif %}
     {% if established_str is not none %} {{ established_str }} {% endif %}
+    {% if icmp_filter_str is not none %} {{ icmp_filter_str }} {% endif %}
     {% if drop_precedence_str is not none %}
         {{ drop_precedence_str }} {% endif %}
     {% if drop_precedence_force_str is not none %}


### PR DESCRIPTION
MLX supports ICMP filter for protocol type ICMP. Added a parameter icmp_filter in action to support this option. Hence adding the code in pyswitch library to handle this parameter.

st2 run network_essentials.add_ipv4_rule_acl username=admin password=admin mgmt_ip=10.37.73.148 acl_name=ACL_IP_extended_test action=permit protocol_type=icmp source='2.2.2.2 0.0.0.255' destination='3.3.3.3 0.0.0.255' icmp_filter='echo-reply'

st2 run network_essentials.add_ipv4_rule_acl username=admin password=admin mgmt_ip=10.37.73.148 acl_name=ACL_IP_extended_test action=permit protocol_type=icmp source='2.2.2.2 0.0.0.255' destination='3.3.3.3 0.0.0.255' icmp_filter='3 0'

NOTE: icmp_filter for type and code is supported for specific combination, user should refer to configuration guide to try such combinations else failed combination will be reported to user if action is executed.