### PR TITLE
Fix for defects MLX-73, MLX-102, MLX-92, MLX-115

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -158,6 +158,8 @@ class Interface(BaseInterface):
                 raise ValueError('Port-channel name should be 1-64 characters')
             if int(portchannel_num) < 1 or int(portchannel_num) > 256:
                 raise ValueError('Port-channel id should be between 1 and 256')
+            if int_type != 'ethernet':
+                raise ValueError('Not a valid interface type (%s) for MLX' % (int_type))
             # Check if a port-channel exists with same id TBD in action
             cli_arr.append('lag' + " " + '"' + desc + '"' + " " + str(mode) + " " + 'id' +
                     " " + str(portchannel_num))


### PR DESCRIPTION
Fix for defects MLX-73, MLX-102, MLX-92, MLX-115.
- Handle error scenarios for invalid interface type

Logs:
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.create_l2_port_channel mgmt_ip='10.24.85.107' username='admin' password='admin' intf_type='tengigabitethernet' ports='2/1/0,2/2/0' mode='standard' protocol='active' port_channel_desc='po50' port_channel_id='50'
......
id: 5a0fa1cec4da5f6616808749
status: failed
parameters: 
  intf_type: tengigabitethernet
  mgmt_ip: 10.24.85.107
  mode: standard
  password: '********'
  port_channel_desc: po50
  port_channel_id: '50'
  ports:
  - 2/1/0
  - 2/2/0
  protocol: active
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.24.85.107 to create port channel

    st2.actions.python.CreatePortChannel: ERROR    Failed to create Port-channel!! Not a valid interface type (tengigabitethernet) for MLX

    st2.actions.python.CreatePortChannel: ERROR    Port channel creation with id 50 desc po50 failed

    '
  stdout: ''
