### PR TITLE
CANDY-853 Fix

### DIFF
--- a/pyswitch/os/slxos/base/cluster.py
+++ b/pyswitch/os/slxos/base/cluster.py
@@ -544,6 +544,8 @@ class Cluster(object):
         principal_mac_node = self.get_key_with_namespace(root, namespace, 'principal-switch-mac')
         if principal_mac_node is not None:
             output['principal-switch-mac'] = principal_mac_node.text
+        else:
+            output['principal-switch-mac'] = ''
         num_node_node = self.get_key_with_namespace(root, namespace, 'total-nodes-in-cluster')
         if num_node_node is not None:
             output['num-nodes'] = num_node_node.text


### PR DESCRIPTION
cluster_mgmt_get() makes a REST Call to fetch the details. In standalone mode, REST API does not return 'principal_node_mac'. Fix is to just set an empty string in case of is not available. 