### PR TITLE
Fix for MLX-167 and MLX-169

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -175,7 +175,6 @@ class Interface(BaseInterface):
                 lag_member_dict = {}
                 lag_member_dict = self.get_port_channel_member_ports(desc)
                 member_cnt = len(lag_member_dict)
-            print "mbr cnt", member_cnt
             if member_cnt == 0:
                 # select primary port
                 cli_arr.append('primary-port' + " " + ports[0])

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -122,7 +122,7 @@ class Interface(BaseInterface):
             reason = error.message
             raise ValueError('Failed to create VLAN %s' % (reason))
 
-    def create_port_channel(self, ports, int_type, portchannel_num, mode, desc=None):
+    def create_port_channel(self, ports, int_type, portchannel_num, mode, po_exists, desc=None):
         """create port channel
 
         args:
@@ -165,14 +165,22 @@ class Interface(BaseInterface):
                     " " + str(portchannel_num))
             # Add ports to port-channel
             port_list = []
+            member_cnt = 0
             for port in ports:
                 port_list.append(int_type + " " + port)
             port_list_str = " ".join(port_list)
             cli_arr.append('ports' + " " + port_list_str)
-            # select primary port
-            cli_arr.append('primary-port' + " " + ports[0])
-            # deploy the port channel
-            cli_arr.append('deploy')
+            if po_exists:
+                # Determine if primary port election is required
+                lag_member_dict = {}
+                lag_member_dict = self.get_port_channel_member_ports(desc)
+                member_cnt = len(lag_member_dict)
+            print "mbr cnt", member_cnt
+            if member_cnt == 0:
+                # select primary port
+                cli_arr.append('primary-port' + " " + ports[0])
+                # deploy the port channel
+                cli_arr.append('deploy')
             # Enable the member ports
             cli_arr.append('enable' + " " + port_list_str)
             output = self._callback(cli_arr, handler='cli-set')
@@ -490,6 +498,9 @@ class Interface(BaseInterface):
         cli_arr = 'show lag | inc Deployed'
         po_list = []
         output = self._callback(cli_arr, handler='cli-get')
+        if output == '':
+            return po_list
+
         error = re.search(r'Error(.+)', output)
         if error:
             raise ValueError("%s" % error.group(0))

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -130,6 +130,7 @@ class Interface(BaseInterface):
             ports(list): port numbers (1/1, 2/1 etc)
             portchannel_num (int): port-channel number (1, 2, 3, etc).
             mode (str): mode of port-channel (static, dynamic)
+            po_exists (bool): notifies is PO is already created
             desc: name of port-channel
 
         returns:
@@ -145,7 +146,7 @@ class Interface(BaseInterface):
             >>> with pyswitch.device.Device(conn=conn, auth=auth) as dev:
             ...     ports = ['2/1', '2/2']
             ...     output = dev.interface.create_port_channel(ports, 'ethernet',
-            ...                         50, 'static', 'po50')
+            ...                         50, 'static', False, 'po50')
             ...     assert output == True
             ...     ifindex = dev.interface.get_port_channel_ifindex('po50')
             ...     assert len(str(ifindex)) >= 1


### PR DESCRIPTION
logs:

ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.create_l2_port_channel mgmt_ip='10.24.85.107' username='admin' password='admin' intf_type='ethernet' ports='2/1' mode='standard' protocol='modeon' port_channel_desc='po50' port_channel_id='50'
........
id: 5a1eae82c4da5f66168088a8
status: succeeded
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  mode: standard
  password: '********'
  port_channel_desc: po50
  port_channel_id: '50'
  ports:
  - 2/1
  protocol: modeon
  username: admin
result: 
  exit_code: 0
  result:
    port_channel_configs: true
    pre_validation: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.24.85.107 to create port channel

    st2.actions.python.CreatePortChannel: INFO     Configuring port channel 50 with type as static on interfaces [u''2/1''] is done

    st2.actions.python.CreatePortChannel: INFO     intf_type ethernet ports [u''2/1'']

    st2.actions.python.CreatePortChannel: INFO     closing connection to 10.24.85.107 after configuring port channel -- all done!

