### PR TITLE
Fix for MLX-172

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1414,10 +1414,12 @@ class Interface(BaseInterface):
         if get:
             enable = None
             ve_list = []
-            cli_arr = 'show running-config interface | inc ve'
+            cli_arr = 'show running-config interface | inc interface ve'
             output = self._callback(cli_arr, handler='cli-get')
             for line in output.split('\n'):
                 info = re.search(r'interface ve (.+)', line)
+                if info is None:
+                    continue
                 ve_id = info.group(1)
                 if ve_id:
                     ve_list.append(ve_id)
@@ -1458,7 +1460,7 @@ class Interface(BaseInterface):
         """
 
         ve_list = []
-        cli_arr = 'show running-config interface | inc ve'
+        cli_arr = 'show running-config interface | inc interface ve'
         output = self._callback(cli_arr, handler='cli-get')
         error = re.search(r'Error(.+)', output)
         if error:
@@ -1466,6 +1468,8 @@ class Interface(BaseInterface):
         # Populate the VE interface list with default data and update later
         for line in output.split('\n'):
             info = re.search(r'interface ve (.+)', line)
+            if info is None:
+                continue
             ve_id = info.group(1)
             if_name = 'Ve ' + ve_id
             ve_info = {'interface-type': 've',


### PR DESCRIPTION
Logs:

ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.create_ve mgmt_ip='10.24.85.107' username='admin' password='admin' vlan_id='160' ve_id=161  ip_address='161.9.9.4/24'
...................
id: 5a204589c4da5f6616808902
status: succeeded
parameters: 
  ip_address:
  - 161.9.9.4/24
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  ve_id: '161'
  vlan_id: '160'
result: 
  exit_code: 0
  result:
    assign_ip: true
    create_ve: true
    pre_validation_ip: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateVe: INFO     successfully connected to 10.24.85.107 to create Ve

    st2.actions.python.CreateVe: INFO     Creating VE 161 on rbridge-id None

    st2.actions.python.CreateVe: INFO     Assigning IP address 161.9.9.4/24 to VE 161 on rbridge-id None

    st2.actions.python.CreateVe: INFO     closing connection to 10.24.85.107 after creating Ve -- all done!

    '
  stdout: ''
