### PR TITLE
MLX-147 fix

### DIFF
--- a/pyswitch/snmp/base/acl/ipacl.py
+++ b/pyswitch/snmp/base/acl/ipacl.py
@@ -124,7 +124,7 @@ class IpAcl(AclParamParser):
         Examples:
         """
         if 'destination' not in parameters or not parameters['destination']:
-            raise ValueError("\'destination\' is required param for MLX")
+            raise ValueError("\'destination\' is required param")
 
         if 'protocol_type' not in parameters or \
                 not parameters['protocol_type']:

--- a/pyswitch/snmp/base/acl/ipacl.py
+++ b/pyswitch/snmp/base/acl/ipacl.py
@@ -124,7 +124,7 @@ class IpAcl(AclParamParser):
         Examples:
         """
         if 'destination' not in parameters or not parameters['destination']:
-            return None
+            raise ValueError("\'destination\' is required param for MLX")
 
         if 'protocol_type' not in parameters or \
                 not parameters['protocol_type']:

--- a/pyswitch/snmp/base/acl/ipv6acl.py
+++ b/pyswitch/snmp/base/acl/ipv6acl.py
@@ -185,7 +185,7 @@ class Ipv6Acl(AclParamParser):
         Examples:
         """
         if 'destination' not in parameters or not parameters['destination']:
-            raise ValueError("Missing \'destination\' is parameters")
+            raise ValueError("\'destination\' is required param for MLX")
 
         if 'protocol_type' not in parameters or \
                 not parameters['protocol_type']:

--- a/pyswitch/snmp/base/acl/ipv6acl.py
+++ b/pyswitch/snmp/base/acl/ipv6acl.py
@@ -185,7 +185,7 @@ class Ipv6Acl(AclParamParser):
         Examples:
         """
         if 'destination' not in parameters or not parameters['destination']:
-            raise ValueError("\'destination\' is required param for MLX")
+            raise ValueError("\'destination\' is required param")
 
         if 'protocol_type' not in parameters or \
                 not parameters['protocol_type']:

--- a/pyswitch/snmp/base/acl/macacl.py
+++ b/pyswitch/snmp/base/acl/macacl.py
@@ -98,7 +98,7 @@ class MacAcl(AclParamParser):
         """
         dst_mac_addr_mask = None
         if 'dst' not in parameters or not parameters['dst']:
-            raise ValueError("\'dst\' is required param for MLX")
+            raise ValueError("\'dst\' is required param")
 
         if 'dst_mac_addr_mask' in parameters:
             dst_mac_addr_mask = parameters['dst_mac_addr_mask']


### PR DESCRIPTION
destination is required parameter for extended access-list.
Instead of returning None changed to raise exception.

**Action**:  
st2 run network_essentials.add_ipv4_rule_acl username=admin    password=admin  mgmt_ip=10.37.73.148     acl_name=ACL_IP_extended_test source=any

**Result**: (Partial Output)
...
...
File \"/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/snmp/mlx/base/acl/acl.py\", line 748, in parse_params_for_add_ipv4_extended\n    user_data['dst_str'] = self.ip.parse_destination(**parameters)\n  File \"/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/snmp/base/acl/ipacl.py\", line 127, in parse_destination\n    raise ValueError(\"\\'destination\\' is required param for MLX\")\nValueError: 'destination' is required param\n"
  stdout: ''

