### PR TITLE
CANDY-928: Making these parameters as not accepted by slx and vdx

### DIFF
--- a/pyswitch/raw/slx_nos/acl/acl_template.py
+++ b/pyswitch/raw/slx_nos/acl/acl_template.py
@@ -58,18 +58,20 @@ acl_get_config = """
 <get-config>
   <source> <running/> </source>
 
-  {% if address_type != "mac" -%}
+  {% if acl_type == "standard" -%}
 
     <nc:filter type='xpath' select='/{{address_type}}-acl/{{address_type}}/\
-access-list/{{acl_type}}[name=\"{{acl_name}}\"]'>
+access-list/{{acl_type}}[name=\"{{acl_name}}\"]/\
+hide-{{address_type}}-acl-std/seq/seq-id'></nc:filter>
 
   {% else -%}
 
-    <nc:filter type='xpath' select='/{{address_type}}/access-list/\
-{{acl_type}}[name=\"{{acl_name}}\"]/hide-mac-acl-ext/seq/seq-id'>
+    <nc:filter type='xpath' select='/{{address_type}}-acl/{{address_type}}/\
+access-list/{{acl_type}}[name=\"{{acl_name}}\"]/\
+hide-{{address_type}}-acl-ext/seq/seq-id'></nc:filter>
 
   {% endif %}
-    </nc:filter>
+
 </get-config>
 """
 
@@ -252,4 +254,11 @@ acl_remove = """
       </rbridge-id>
    {% endif %}
 </config>
+"""
+
+get_interface_by_name = """
+<get-config>
+  <source> <running/> </source>
+  <nc:filter type='xpath' select='/interface/{{intf_type}}[name=\"{{intf_name}}\"]'> </nc:filter>
+</get-config>
 """

--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -170,7 +170,7 @@ def validate_params_nos_remove_acl(**parameters):
 
     required_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
     accepted_params = ['intf_type', 'rbridge_id', 'acl_name', 'intf_name',
-                       'traffic_type', 'acl_direction']
+                       'acl_direction']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]
@@ -283,8 +283,7 @@ def validate_params_slx_apply_acl(**parameters):
 def validate_params_slx_remove_acl(**parameters):
 
     required_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
-    accepted_params = ['intf_type', 'acl_name', 'intf_name', 'traffic_type',
-                       'acl_direction']
+    accepted_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]


### PR DESCRIPTION
device types. Throwing exception if provided.