### PR TITLE
[MLX-188] Return error to pass vlan-id as mandatory for mlx

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -1123,6 +1123,10 @@ class Interface(object):
         ctag = kwargs.pop('ctag', None)
         vlan = kwargs.pop('vlan', None)
 
+        # user wanted to set just port mode to trunk
+        if action is None and vlan == []:
+            return
+
         if action not in valid_actions:
             raise ValueError('%s must be one of: %s' %
                              (action, valid_actions))

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1041,7 +1041,7 @@ class Interface(BaseInterface):
 
         callback = kwargs.pop('callback', self._callback)
 
-        int_types = self.valid_int_types
+        int_types = ['ethernet', 'port_channel']
         valid_actions = ['add', 'remove']
 
         if int_type not in int_types:
@@ -1050,6 +1050,9 @@ class Interface(BaseInterface):
 
         action = kwargs.pop('action')
         vlan = kwargs.pop('vlan', None)
+
+        if action is None and vlan == []:
+            raise ValueError("vlan id must be passed for MLX")
 
         if action not in valid_actions:
             raise ValueError('%s must be one of: %s' %


### PR DESCRIPTION
$ st2 run network_essentials.create_switchport_trunk mgmt_ip=10.24.85.103 intf_type=ethernet intf_name=0/1 username=admin password=password
............
id: 5a307d8cc4da5f0571347fa5
status: succeeded
parameters: 
  intf_name: 0/1
  intf_type: ethernet
  mgmt_ip: 10.24.85.103
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.85.103 to create switchport on Interface

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 0/1

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface

    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.24.85.103 after configuring switch port on interface -- all done!

    '
  stdout: ''
vagrant (trunk *) actions
$ st2 run network_essentials.create_switchport_trunk mgmt_ip=10.24.85.107 intf_type=port_channel intf_name=3 username=admin password=admin
.....
id: 5a307de1c4da5f0571347fa8
status: failed
parameters: 
  intf_name: '3'
  intf_type: port_channel
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
result: 
  exit_code: 1
  result: None
  stderr: "st2.actions.python.ABCMeta: AUDIT    Creating new Client object.\nNo handlers could be found for logger \"st2.st2common.services.access\"\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)\nst2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.85.107 to create switchport on Interface\nst2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 3\nst2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface\nst2.actions.python.CreateSwitchPort: ERROR    Configuring Switch port trunk vlans failed due to vlan id must be passed for MLX\nTraceback (most recent call last):\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 239, in _switchport_vlans\n    vlan=vlan_id)\n  File \"/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/snmp/mlx/base/interface.py\", line 1055, in trunk_allowed_vlan\n    raise ValueError(\"vlan id must be passed for MLX\")\nValueError: vlan id must be passed for MLX\nst2.actions.python.CreateSwitchPort: ERROR    Error encountered on 10.24.85.107 due to Configuring Switch port trunk vlans failed\nTraceback (most recent call last):\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 966, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 87, in switch_operation\n    v_list, c_list)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 249, in _switchport_vlans\n    raise ValueError(\"Configuring Switch port trunk vlans failed\")\nValueError: Configuring Switch port trunk vlans failed\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 259, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 155, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 40, in run\n    trunk_no_default_native)\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 966, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 87, in switch_operation\n    v_list, c_list)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 249, in _switchport_vlans\n    raise ValueError(\"Configuring Switch port trunk vlans failed\")\nValueError: Configuring Switch port trunk vlans failed\n"
  stdout: ''
vagrant (trunk *) actions
$ st2 run network_essentials.create_switchport_trunk mgmt_ip=10.24.85.103 intf_type=ethernet intf_name=0/1 username=admin password=password vlan_id=10
......
id: 5a307e3dc4da5f0571347fab
status: succeeded
parameters: 
  intf_name: 0/1
  intf_type: ethernet
  mgmt_ip: 10.24.85.103
  password: '********'
  username: admin
  vlan_id: '10'
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.103.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.85.103 to create switchport on Interface

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 0/1

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface

    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.24.85.103 after configuring switch port on interface -- all done!

    '
  stdout: ''
vagrant (trunk *) actions
$ st2 run network_essentials.create_switchport_trunk mgmt_ip=10.24.85.107 intf_type=port_channel intf_name=3 username=admin password=admin vlan_id=600
.......
id: 5a307ec9c4da5f0571347fae
status: succeeded
parameters: 
  intf_name: '3'
  intf_type: port_channel
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vlan_id: '600'
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.85.107 to create switchport on Interface

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 3

    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface

    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.24.85.107 after configuring switch port on interface -- all done!

    '
  stdout: ''
vagrant (trunk *) actions
$ 
