### PR TITLE
Fix for defects MLX-223,MLX-228,MLX-248

### DIFF
--- a/pyswitch/snmp/SnmpMib.py
+++ b/pyswitch/snmp/SnmpMib.py
@@ -6,9 +6,9 @@ class SnmpMib:
     """
     mib_oid_map = {
         'sysObjectId': '1.3.6.1.2.1.1.2.0',
-        'dot1qVlanStaticTable': '1.3.6.1.2.1.17.7.1.4.3.1',
-        'dot1qVlanStaticEntry': '1.3.6.1.2.1.17.7.1.4.3.1.1',
-        'dot1qVlanStaticName': '1.3.6.1.2.1.17.7.1.4.3.1.2',
+        'dot1qVlanStaticTable': '1.3.6.1.2.1.17.7.1.4.3',
+        'dot1qVlanStaticEntry': '1.3.6.1.2.1.17.7.1.4.3.1',
+        'dot1qVlanStaticName': '1.3.6.1.2.1.17.7.1.4.3.1.1',
         'dot1qVlanStaticEgressPorts': '1.3.6.1.2.1.17.7.1.4.3.1.2',
         'dot1qVlanStaticUntaggedPorts': '1.3.6.1.2.1.17.7.1.4.3.1.4',
         'dot1qVlanStaticRowStatus': '1.3.6.1.2.1.17.7.1.4.3.1.5',


### PR DESCRIPTION
Fix for defects MLX-223,MLX-228,MLX-248.
- Fix the snmp oid issue which was causing validate_vlan to fail. 
- Edit the data type for port-channel id from string to integer in validate_l2_port_channel_state.yaml. With this change only one po id can be entered at a time
- Existing issue where port-channel state validation check is incorrectly computed if there a member port which is out of sync which happens to be computed last and other members of port-channel are in sync.

Logs:
ubuntu@st2vagrant:~/bash_scripts$  st2 run network_essentials.validate_L2_port_channel_state mgmt_ip=10.20.179.132 port_channel_id=1
........
id: 5a377869c4da5f37c54b285c
status: succeeded
parameters: 
  mgmt_ip: 10.20.179.132
  port_channel_id: 1
result: 
  exit_code: 0
  result:
    member-ports:
    - ethernet 8/4
    - ethernet 8/1
    - ethernet 8/3
    state: in_sync
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateL2PortChannelState: INFO     successfully connected to 10.20.179.132 to validate l2 port channel

    st2.actions.python.ValidateL2PortChannelState: INFO     ethernet 8/1 is out of sync

    st2.actions.python.ValidateL2PortChannelState: INFO     ethernet 8/3 is out of sync

    st2.actions.python.ValidateL2PortChannelState: INFO     closing connection to 10.20.179.132 after validation of port channel -- all done!

    '
  stdout: '{''interface-type'': ''ethernet'', ''rbridge-id'': 0, ''interface-name'': u''8/4'', ''sync'': ''1'', ''actor_port'': 144}

    {''interface-type'': ''ethernet'', ''rbridge-id'': 0, ''interface-name'': u''8/1'', ''sync'': ''0'', ''actor_port'': 141}

    {''interface-type'': ''ethernet'', ''rbridge-id'': 0, ''interface-name'': u''8/3'', ''sync'': ''0'', ''actor_port'': 143}

    '

ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_L2_port_channel_state mgmt_ip=10.20.179.132 port_channel_id=1,2,3
ERROR: invalid literal for int() with base 10: '1,2,3'

ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_vlan mgmt_ip=10.20.179.132 vlan_id=2221 intf_type=ethernet intf_name=8/11 
....
id: 5a378a51c4da5f37c54b285f
status: succeeded
parameters: 
  intf_name: 8/11
  intf_type: ethernet
  mgmt_ip: 10.20.179.132
  vlan_id: '2221'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.20.179.132 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    '
  stdout: ''
	
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_vlan mgmt_ip=10.20.179.132 vlan_id=2221 intf_type=ethernet intf_name=8/12 
....
id: 5a378a9dc4da5f37c54b2862
status: succeeded
parameters: 
  intf_name: 8/12
  intf_type: ethernet
  mgmt_ip: 10.20.179.132
  vlan_id: '2221'
result: 
  exit_code: 0
  result:
    vlan: false
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.20.179.132 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    '
  stdout: ''
ubuntu@st2vagrant:~/bash_scripts$ 
  
  
  
  