### PR TITLE
MLX-59: Device optimization

### DIFF
--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -122,7 +122,7 @@ class SnmpCliDevice(AbstractDevice):
         ns_daemon_dict = ConfigFileUtil().read(filename=pyswitchlib_ns_daemon_file)
 
         if pyswitchlib_daemon in ns_daemon_dict:
-            uri = ns_daemon_dict['api_daemon_virtualenv_packs']
+            uri = ns_daemon_dict[pyswitchlib_daemon]
             with Pyro4.Proxy(uri) as pyro_proxy:
                 pyro_proxy._pyroBind()
                 self._proxied = pyro_proxy

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -83,7 +83,7 @@ class PySwitchLibApiDaemon(object):
             else:
                 # case 3: Assume user value is new so delete existing
                 # and add new connection object for this
-                conn_obj = self.get_netmiko_connection(key)
+                conn_obj = self._get_netmiko_connection(key)
                 conn_obj.disconnect()
                 del net_connect_dict[key]
                 try:
@@ -114,7 +114,7 @@ class PySwitchLibApiDaemon(object):
             raise ValueError('Failed to connect to switch %s' % reason)
         return net_connect
 
-    def get_netmiko_connection(self, key):
+    def _get_netmiko_connection(self, key):
         if key in self._netmiko_connection:
             return self._netmiko_connection[key][0]
         else:
@@ -122,7 +122,7 @@ class PySwitchLibApiDaemon(object):
 
     def cli_execution(self, handler, host, call):
         value = ''
-        conn_obj = self.get_netmiko_connection(host)
+        conn_obj = self._get_netmiko_connection(host)
         if not conn_obj:
             return value
         try:

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -6,6 +6,8 @@ import json
 import re
 import Pyro4
 import Pyro4.naming
+import uuid
+import hashlib
 import pyangbind.lib.pybindJSON as pybindJSON
 from pyswitchlib.util.configFile import ConfigFileUtil
 from pyswitchlib.util.config import ConfigUtil
@@ -14,6 +16,9 @@ from collections import OrderedDict
 from dicttoxml import dicttoxml
 from daemon.runner import (DaemonRunner, DaemonRunnerStopFailureError)
 from lockfile import LockTimeout
+from netmiko import ConnectHandler
+from netmiko.ssh_exception import NetMikoTimeoutException, NetMikoAuthenticationException
+from paramiko.ssh_exception import SSHException
 
 pyswitchlib_conf_file = os.path.join(os.sep, 'etc', 'pyswitchlib', 'pyswitchlib.conf')
 pyswitchlib_ns_daemon_file = os.path.join(os.sep, 'etc', 'pyswitchlib', '.pyswitchlib_ns_daemon.uri')
@@ -34,6 +39,102 @@ class PySwitchLibApiDaemon(object):
         self._module_obj = module_obj
         self._api_lock = threading.Lock()
         self._pyro_daemon = pyro_daemon
+        self._netmiko_lock = threading.Lock()
+        self._netmiko_connection = {}
+
+    def _hash_auth_string(self, auth_str):
+        salt = uuid.uuid4().hex
+        user = auth_str[0]
+        passwd = auth_str[1]
+        encode_str = hashlib.sha256(salt.encode() + user.encode() + passwd.encode()).hexdigest()
+        return encode_str + ':' + salt
+
+    def _check_auth_string(self, hashed_str, new_auth):
+        auth_str, salt = hashed_str.split(':')
+        user = new_auth[0]
+        passwd = new_auth[1]
+        new_hash = hashlib.sha256(salt.encode() + user.encode() + passwd.encode()).hexdigest()
+        return auth_str == new_hash
+
+    def create_netmiko_connection(self, opt):
+        key = opt['ip']
+        conn_list = ['None', 'None']
+        net_connect_dict = self._netmiko_connection
+        auth = (opt['username'], opt['password'])
+        if key not in net_connect_dict:
+            # case 1: No key create a connection
+            try:
+                net_connect = self._establish_netmiko_handler(opt, net_connect_dict)
+                if net_connect:
+                    hashed_auth = self._hash_auth_string(auth)
+                    conn_list[0] = net_connect
+                    conn_list[1] = hashed_auth
+                    net_connect_dict[key] = conn_list
+            except ValueError as err:
+                raise
+            except Exception as err:
+                raise
+
+        else:
+            existing_hash = net_connect_dict[key][1]
+            if self._check_auth_string(existing_hash, auth):
+                # case 2: Validation success do nothing
+                return
+            else:
+                # case 3: Assume user value is new so delete existing
+                # and add new connection object for this
+                conn_obj = self.get_netmiko_connection(key)
+                conn_obj.disconnect()
+                del net_connect_dict[key]
+                try:
+                    net_connect = self._establish_netmiko_handler(opt, net_connect_dict)
+                    if net_connect:
+                        new_hash = self._hash_auth_string(auth)
+                        conn_list[0] = net_connect
+                        conn_list[1] = new_hash
+                        net_connect_dict[key] = conn_list
+                except ValueError as error:
+                    raise
+                except Exception:
+                    raise Exception
+
+    def _establish_netmiko_handler(self, opt, net_connect_dict):
+        key = opt['ip']
+        try:
+            net_connect = ConnectHandler(**opt)
+            net_connect_dict[key] = net_connect
+        except (NetMikoTimeoutException, NetMikoAuthenticationException,) as error:
+            reason = error.message
+            raise ValueError('[Netmiko Exception:] %s' % reason)
+        except SSHException as error:
+            reason = error.message
+            raise ValueError('[SSH Exception:] %s' % reason)
+        except Exception as error:
+            reason = error.message
+            raise ValueError('Failed to connect to switch %s' % reason)
+        return net_connect
+
+    def get_netmiko_connection(self, key):
+        if key in self._netmiko_connection:
+            return self._netmiko_connection[key][0]
+        else:
+            return None
+
+    def cli_execution(self, handler, host, call):
+        value = ''
+        conn_obj = self.get_netmiko_connection(host)
+        if not conn_obj:
+            return value
+        try:
+            if handler == 'cli-set':
+                conn_obj.enable()
+                value = conn_obj.send_config_set(call)
+            elif handler == 'cli-get':
+                value = conn_obj.send_command(call)
+        except Exception:
+            raise Exception
+
+        return value
 
     def shutdown(self):
         """
@@ -49,6 +150,20 @@ class PySwitchLibApiDaemon(object):
         """
 
         self._module_name = module_name
+
+    def netmiko_acquire(self):
+        """
+        This is an auto-generated method for the PySwitchLib.
+        """
+
+        self._netmiko_lock.acquire()
+
+    def netmiko_release(self):
+        """
+        This is an auto-generated method for the PySwitchLib.
+        """
+
+        self._netmiko_lock.release()
 
     def api_acquire(self):
         """


### PR DESCRIPTION
MLX device connection takes 5-7 seconds. This is an big overhead as every action initiates the connection.  To avoid this overhead moved the netmiko connection to pyswitchlib api daemon. First time connection will take 5-7 seconds and then this connection object will be stored with hash keys user name and password. If there is a change in credentials then the old connection will be deleted and new connection object will be initiated. 

```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.20.179.132 targets=1001::1 vrf=test_ping_vrf count=2 
.....
id: 5a4d34babb0f18081ac6b024
status: succeeded
parameters: 
  count: 2
  mgmt_ip: 10.20.179.132
  targets:
  - 1001::1
  vrf: test_ping_vrf
result: 
  exit_code: 0
  result: "[\n    {\n        \"ip_address\": \"1001::1\",\n        \"packet loss\": \"100%\",\n        \"packets received\": 0,\n        \"packets transmitted\": 0,\n        \"result\": \"fail\"\n    }\n]"
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: 'ping ipv6 vrf test_ping_vrf 1001::1 count 2 datagram-size 56 timeout 50

    '

real	0m11.176s
user	0m0.564s
sys	0m0.056s
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.20.179.132 targets=1001::1 vrf=test_ping_vrf count=2 
...
id: 5a4d34cabb0f18081ac6b027
status: succeeded
parameters: 
  count: 2
  mgmt_ip: 10.20.179.132
  targets:
  - 1001::1
  vrf: test_ping_vrf
result: 
  exit_code: 0
  result: "[\n    {\n        \"ip_address\": \"1001::1\",\n        \"packet loss\": \"100%\",\n        \"packets received\": 0,\n        \"packets transmitted\": 0,\n        \"result\": \"fail\"\n    }\n]"
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: 'ping ipv6 vrf test_ping_vrf 1001::1 count 2 datagram-size 56 timeout 50

    '

real	0m7.162s
user	0m0.560s
sys	0m0.088s
```