### PR TITLE
create a vrf name with space

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1272,6 +1272,7 @@ class Interface(BaseInterface):
 
         if not get_config:
             vrf_name = kwargs['vrf_name']
+            vrf_name = '"' + vrf_name + '"'
             cli_arr = []
             if delete:
                 cli_arr.append('no vrf ' + vrf_name)
@@ -1343,6 +1344,7 @@ class Interface(BaseInterface):
             afi = kwargs['afi']
             afi = 'ipv4' if (afi == 'ip') else afi
             vrf_name = kwargs['vrf_name']
+            vrf_name = '"' + vrf_name + '"'
             cli_arr.append('vrf ' + vrf_name)
 
             if delete is True:
@@ -1363,6 +1365,7 @@ class Interface(BaseInterface):
 
         elif get_config:
             vrf_name = kwargs.pop('vrf_name', '')
+            vrf_name = '"' + vrf_name + '"'
 
             cli_cmd = 'show vrf ' + vrf_name
             cli_output = callback(cli_cmd, handler='cli-get')

--- a/pyswitch/utilities.py
+++ b/pyswitch/utilities.py
@@ -388,7 +388,7 @@ def check_mlx_cli_set_error(cli_res):
     """
        check whether any error or invalid input during cli-set operation
     """
-    error = re.search(r'Error(.+)', cli_res)
+    error = re.search(r'(E|e)rror(.+)', cli_res)
     invalid_input = re.search(r'Invalid input', cli_res)
     if error:
         raise ValueError("%s" % error.group(0))


### PR DESCRIPTION
$ st2 run network_essentials.create_vrf mgmt_ip=10.20.179.132 vrf_name="vrf mlx" afi=ipv4 rd=10:240
..........
id: 5a4d9ea8c4da5f0571348104
status: succeeded
parameters: 
  afi: ipv4
  mgmt_ip: 10.20.179.132
  rd: 10:240
  vrf_name: vrf mlx
result: 
  exit_code: 0
  result:
    Create_VRF: true
    Create_address_family: true
  stderr: "st2.actions.python.ABCMeta: AUDIT    Creating new Client object.\nNo handlers could be found for logger \"st2.st2common.services.access\"\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)\nst2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)\nst2.actions.python.CreateVRF: INFO     successfully connected to 10.20.179.132 to Create VRF for tenants\npyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to Create VRF for tenants\nst2.actions.python.CreateVRF: INFO     Creating VRF vrf mlx \npyswitch.snmp.base.acl.Acl: INFO  Creating VRF vrf mlx \nst2.actions.python.CreateVRF: INFO     vrf name type <type 'unicode'>\npyswitch.snmp.base.acl.Acl: INFO  vrf name type <type 'unicode'>\nst2.actions.python.CreateVRF: INFO     Rbridge id type <type 'NoneType'>\npyswitch.snmp.base.acl.Acl: INFO  Rbridge id type <type 'NoneType'>\nst2.actions.python.CreateVRF: INFO     Creating ipv4 address family for VRF vrf mlx \npyswitch.snmp.base.acl.Acl: INFO  Creating ipv4 address family for VRF vrf mlx \nst2.actions.python.CreateVRF: INFO     closing connection to 10.20.179.132 after Create VRF - all done!\npyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.20.179.132 after Create VRF - all done!\nst2.actions.python.CliCMD: INFO     successfully connected to None to find execute CLI [u'show vrf \"vrf mlx\"']\npyswitch.snmp.base.acl.Acl: INFO  successfully connected to None to find execute CLI [u'show vrf \"vrf mlx\"']\nst2.actions.python.CliCMD: INFO     successfully executed cli show vrf \"vrf mlx\"\npyswitch.snmp.base.acl.Acl: INFO  successfully executed cli show vrf \"vrf mlx\"\nst2.actions.python.CliCMD: INFO     closing connection to None after executions cli cmds -- all done!\npyswitch.snmp.base.acl.Acl: INFO  closing connection to None after executions cli cmds -- all done!\nst2.actions.python.CreateVRF: INFO     {u'show vrf \"vrf mlx\"': u'VRF vrf mlx, default RD 10:240, Table ID 1\\nLabel: (Not Allocated),  Label-Switched Mode: OFF\\nIP Router-Id: 0.0.0.0\\n  No interfaces\\n  No Export VPN route-target communities\\n  No Import VPN route-target communities\\n\\n  Address Family IPv4\\n  No import route-map\\n  No export route-map\\n    Max Routes: 5120\\n    Number of Unicast Routes: 0\\n    No Export VPN route-target communities\\n    No Import VPN route-target communities'}\npyswitch.snmp.base.acl.Acl: INFO  {u'show vrf \"vrf mlx\"': u'VRF vrf mlx, default RD 10:240, Table ID 1\\nLabel: (Not Allocated),  Label-Switched Mode: OFF\\nIP Router-Id: 0.0.0.0\\n  No interfaces\\n  No Export VPN route-target communities\\n  No Import VPN route-target communities\\n\\n  Address Family IPv4\\n  No import route-map\\n  No export route-map\\n    Max Routes: 5120\\n    Number of Unicast Routes: 0\\n    No Export VPN route-target communities\\n    No Import VPN route-target communities'}\n"
  stdout: 'SSH connection established to 10.20.179.132:22

    Interactive SSH session established

    '
vagrant (vrrpe *) network_essentials
$ make lint
