### PR TITLE
Ping vrf fix

### DIFF
--- a/pyswitch/os/base/utils.py
+++ b/pyswitch/os/base/utils.py
@@ -193,6 +193,7 @@ class Utils(object):
         failed_ips_list = []
         success_ips_list = []
         final_output = []
+        status = True
         for key, value in cli_output.iteritems():
             output_dict = {}
             if ipv4_address.search(key):
@@ -209,21 +210,23 @@ class Utils(object):
                                      str(value_list[i + 1])).group(1)
                     p_loss = re.search(r'(\d+)(\%)(\spacket\sloss)',
                                        str(value_list[i + 1])).group(1)
-                    if 100 >= int(p_loss) > 0:
-                        failed_ips_list.append(str(ip))
-                        output_dict['ip_address'] = str(ip)
-                        output_dict['result'] = 'fail'
-                        output_dict['packets transmitted'] = p_tx
-                        output_dict['packets received'] = p_rx
-                        output_dict['packet loss'] = p_loss + "%"
-                    elif int(p_loss) == 0:
-                        success_ips_list.append(str(ip))
-                        output_dict['ip_address'] = ip
-                        output_dict['result'] = 'pass'
-                        output_dict['packets transmitted'] = p_tx
-                        output_dict['packets received'] = p_rx
-                        output_dict['packet loss'] = p_loss + "%"
+            if 100 >= int(p_loss) > 0:
+                failed_ips_list.append(str(ip))
+                output_dict['ip_address'] = str(ip)
+                output_dict['result'] = 'fail'
+                output_dict['packets transmitted'] = p_tx
+                output_dict['packets received'] = p_rx
+                output_dict['packet loss'] = p_loss + "%"
+                status = False
+            elif int(p_loss) == 0:
+                success_ips_list.append(str(ip))
+                output_dict['ip_address'] = ip
+                output_dict['result'] = 'pass'
+                output_dict['packets transmitted'] = p_tx
+                output_dict['packets received'] = p_rx
+                output_dict['packet loss'] = p_loss + "%"
             final_output.append(output_dict)
         json_outputformat = json.dumps(
             final_output, sort_keys=True, indent=4, separators=(',', ': '))
-        return json_outputformat
+        json_outputformat = json.loads(json_outputformat)
+        return (status, json_outputformat)

--- a/pyswitch/os/base/utils.py
+++ b/pyswitch/os/base/utils.py
@@ -214,16 +214,16 @@ class Utils(object):
                 failed_ips_list.append(str(ip))
                 output_dict['ip_address'] = str(ip)
                 output_dict['result'] = 'fail'
-                output_dict['packets transmitted'] = p_tx
-                output_dict['packets received'] = p_rx
+                output_dict['packets transmitted'] = int(p_tx)
+                output_dict['packets received'] = int(p_rx)
                 output_dict['packet loss'] = p_loss + "%"
                 status = False
             elif int(p_loss) == 0:
                 success_ips_list.append(str(ip))
                 output_dict['ip_address'] = ip
                 output_dict['result'] = 'pass'
-                output_dict['packets transmitted'] = p_tx
-                output_dict['packets received'] = p_rx
+                output_dict['packets transmitted'] = int(p_tx)
+                output_dict['packets received'] = int(p_rx)
                 output_dict['packet loss'] = p_loss + "%"
             final_output.append(output_dict)
         json_outputformat = json.dumps(

--- a/pyswitch/snmp/mlx/base/utils.py
+++ b/pyswitch/snmp/mlx/base/utils.py
@@ -206,15 +206,15 @@ class Utils(BaseUtils):
             if int(success_rate) != 100:
                 output_dict['ip_address'] = str(ip)
                 output_dict['result'] = 'fail'
-                output_dict['packets transmitted'] = p_tx
-                output_dict['packets received'] = p_rx
+                output_dict['packets transmitted'] = int(p_tx)
+                output_dict['packets received'] = int(p_rx)
                 output_dict['packet loss'] = str(p_loss) + "%"
                 status = False
             else:
                 output_dict['ip_address'] = ip
                 output_dict['result'] = 'pass'
-                output_dict['packets transmitted'] = p_tx
-                output_dict['packets received'] = p_rx
+                output_dict['packets transmitted'] = int(p_tx)
+                output_dict['packets received'] = int(p_rx)
                 output_dict['packet loss'] = str(p_loss) + "%"
             final_output.append(output_dict)
         json_outputformat = json.dumps(

--- a/pyswitch/snmp/mlx/base/utils.py
+++ b/pyswitch/snmp/mlx/base/utils.py
@@ -83,7 +83,6 @@ class Utils(BaseUtils):
         try:
             for cmd in cli_list:
                 cmd = cmd.strip()
-                print cmd
                 cli_output[cmd] = self._callback(cmd, handler='cli-get')
         except Exception as error:
             reason = error.message
@@ -182,6 +181,7 @@ class Utils(BaseUtils):
         cli_output = self._execute_cli(cli_list)
 
         final_output = []
+        status = True
         for key, value in cli_output.iteritems():
             output_dict = {}
             if ipv4_address.search(key):
@@ -209,6 +209,7 @@ class Utils(BaseUtils):
                 output_dict['packets transmitted'] = p_tx
                 output_dict['packets received'] = p_rx
                 output_dict['packet loss'] = str(p_loss) + "%"
+                status = False
             else:
                 output_dict['ip_address'] = ip
                 output_dict['result'] = 'pass'
@@ -218,4 +219,5 @@ class Utils(BaseUtils):
             final_output.append(output_dict)
         json_outputformat = json.dumps(
             final_output, sort_keys=True, indent=4, separators=(',', ': '))
-        return json_outputformat
+        json_outputformat = json.loads(json_outputformat)
+        return (status, json_outputformat)


### PR DESCRIPTION
- Fix the json output and also fail the status even if one target fails.

The below mentioned PR in NE pack will be complete fix:
https://github.com/StackStorm/network_essentials/pull/263


***SLX failure case***
```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.86.96 targets=10.20.179.132,10.24.89.109 count=2 vrf=mgmt-vrf
..............
id: 5a4eb01fbb0f18081ac6b096
status: failed
parameters: 
  count: 2
  mgmt_ip: 10.24.86.96
  targets:
  - 10.20.179.132
  - 10.24.89.109
  vrf: mgmt-vrf
result: 
  exit_code: 0
  result:
  - ip_address: 10.24.89.109
    packet loss: 100%
    packets received: 0
    packets transmitted: 2
    result: fail
  - ip_address: 10.20.179.132
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: 'SSH connection established to 10.24.86.96:22

    Interactive SSH session established

    '

real	0m29.628s
user	0m0.572s
sys	0m0.112s
```

***SLX Success case***
```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.86.96 targets=10.20.179.132,10.24.85.107 count=2 vrf=mgmt-vrf
.........
id: 5a4eb053bb0f18081ac6b099
status: succeeded
parameters: 
  count: 2
  mgmt_ip: 10.24.86.96
  targets:
  - 10.20.179.132
  - 10.24.85.107
  vrf: mgmt-vrf
result: 
  exit_code: 0
  result:
  - ip_address: 10.24.85.107
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  - ip_address: 10.20.179.132
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: 'SSH connection established to 10.24.86.96:22

    Interactive SSH session established

    '

real	0m19.421s
user	0m0.540s
sys	0m0.108s
```
***MLX success case***
```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.20.179.132 targets=10.24.86.96,10.24.85.107 count=2 
...
id: 5a4eb08bbb0f18081ac6b09c
status: succeeded
parameters: 
  count: 2
  mgmt_ip: 10.20.179.132
  targets:
  - 10.24.86.96
  - 10.24.85.107
result: 
  exit_code: 0
  result:
  - ip_address: 10.24.86.96
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  - ip_address: 10.24.85.107
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: ''

real	0m7.147s
user	0m0.564s
sys	0m0.076s
```

***MLX failure case***
```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.ping_vrf_targets mgmt_ip=10.20.179.132 targets=10.24.86.96,10.24.82.107 count=2 
...
id: 5a4eb0cabb0f18081ac6b09f
status: failed
parameters: 
  count: 2
  mgmt_ip: 10.20.179.132
  targets:
  - 10.24.86.96
  - 10.24.82.107
result: 
  exit_code: 0
  result:
  - ip_address: 10.24.82.107
    packet loss: 100%
    packets received: 0
    packets transmitted: 0
    result: fail
  - ip_address: 10.24.86.96
    packet loss: 0%
    packets received: 2
    packets transmitted: 2
    result: pass
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: ''

real	0m7.097s
user	0m0.508s
sys	0m0.108s
```
  