### PR TITLE
CANDY-869: Added traffic_type check in params validator.

### DIFF
--- a/pyswitch/raw/slx_nos/acl/aclparam_parser.py
+++ b/pyswitch/raw/slx_nos/acl/aclparam_parser.py
@@ -306,6 +306,11 @@ class AclParamParser(object):
         if 'intf_type' not in kwargs or not kwargs['intf_type']:
             raise ValueError("\'intf_type\' not present in kwargs")
 
+        if kwargs['intf_type'] not in ['ve', 'loopback']:
+            if 'rbridge_id' in kwargs and kwargs['rbridge_id']:
+                raise ValueError("\'rbridge_id\' not supported for intf_type: "
+                                 "{}".format(kwargs['intf_type']))
+
         if kwargs['intf_type'] in ['gigabitethernet', 'tengigabitethernet',
                                    'fortygigabitethernet',
                                    'hundredgigabitethernet', 'port_channel',

--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -191,7 +191,7 @@ def validate_params_nos_remove_acl(**parameters):
 
     required_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
     accepted_params = ['intf_type', 'rbridge_id', 'acl_name', 'intf_name',
-                       'acl_direction']
+                       'traffic_type', 'acl_direction']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]
@@ -346,7 +346,8 @@ def validate_params_slx_apply_acl(**parameters):
 def validate_params_slx_remove_acl(**parameters):
 
     required_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
-    accepted_params = ['intf_type', 'acl_name', 'intf_name', 'acl_direction']
+    accepted_params = ['intf_type', 'acl_name', 'intf_name', 'traffic_type',
+                       'acl_direction']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]


### PR DESCRIPTION
Raising exception if rbridge-id is specified for non-ve and non-loopback
interface types.