### PR TITLE
validate interface state for MLX

### DIFF
--- a/pyswitch/snmp/SnmpMib.py
+++ b/pyswitch/snmp/SnmpMib.py
@@ -27,6 +27,7 @@ class SnmpMib:
         'ifXTable': '1.3.6.1.2.1.31.1.1',
         'ifXEntry': '1.3.6.1.2.1.31.1.1.1',
         'ifAdminStatus': '1.3.6.1.2.1.2.2.1.7',
+        'ifOperStatus': '1.3.6.1.2.1.2.2.1.8',
         'ifAlias': '1.3.6.1.2.1.31.1.1.1.18',
         'snRtIpPortIfMtu': '1.3.6.1.4.1.1991.1.2.2.20.1.2',
         'ipv6IfEffectiveMtu': '1.3.6.1.2.1.55.1.5.1.4',

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -702,7 +702,7 @@ class Interface(BaseInterface):
             name (str): Name of interface. (1/1, etc).
 
         Returns:
-            oper state - up/down 
+            oper state - up/down
 
         Raises:
             KeyError: if `int_type`, `name` is not passed
@@ -743,7 +743,6 @@ class Interface(BaseInterface):
             return 'down'
         else:
             return 'invalid'
-
 
     def description(self, **kwargs):
         """Set interface description.

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -694,6 +694,57 @@ class Interface(BaseInterface):
             raise ValueError('Failed to set interface admin status to %s' % (reason))
         return None
 
+    def get_oper_state(self, **kwargs):
+        """Get interface operational state.
+
+        Args:
+            int_type (str): Type of interface. (ethernet, etc).
+            name (str): Name of interface. (1/1, etc).
+
+        Returns:
+            oper state - up/down 
+
+        Raises:
+            KeyError: if `int_type`, `name` is not passed
+
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.85.107']
+            >>> auth = ('admin', 'admin')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         oper_state = dev.interface.get_oper_state(
+            ...                         int_type='ethernet', name='1/1')
+        """
+
+        int_type = kwargs.pop('int_type').lower()
+        name = str(kwargs.pop('name'))
+
+        ifname = int_type + name
+        if int_type == 'port-channel':
+            int_type = 'port_channel'
+            ifname = 'LAG' + name
+        ifname_Ids = self.get_interface_name_id_mapping()
+        if_id = ifname_Ids[ifname]
+        if if_id is None:
+            raise ValueError('Invalid if_id')
+        oid = SnmpMib.mib_oid_map['ifOperStatus']
+        operState_oid = oid + '.' + str(if_id)
+
+        valid_int_types = self.valid_int_types
+        if int_type not in valid_int_types:
+            raise ValueError('`int_type` must be one of: %s' %
+                             str(valid_int_types))
+        oper_state = self._callback(operState_oid, handler='snmp-get')
+        if oper_state == 1:
+            return 'up'
+        elif oper_state == 2:
+            return 'down'
+        else:
+            return 'invalid'
+
+
     def description(self, **kwargs):
         """Set interface description.
 


### PR DESCRIPTION
Fix for defects MLX-216, MLX-217, MLX-218, MLX-219, MLX-221

ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_state mgmt_ip=10.24.85.107 username='admin' password='admin' intf_type=ethernet intf_name=4/3 intf_state=up
..
id: 5a564fb2c4da5f37c54b29bd
status: succeeded
parameters: 
  intf_name: 4/3
  intf_state: up
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    intf: true
    state: up
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceState: INFO     successfully connected to 10.24.85.107 to validate interface state

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.24.85.107 to validate interface state

    st2.actions.python.ValidateInterfaceState: INFO     Successfully validated interface ethernet 4/3 state as up

    pyswitch.snmp.base.acl.Acl: INFO  Successfully validated interface ethernet 4/3 state as up

    st2.actions.python.ValidateInterfaceState: INFO     closing connection to 10.24.85.107 after Validating interface state -- all done!

    pyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.24.85.107 after Validating interface state -- all done!

    '
  stdout: ''

	
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_state mgmt_ip=10.24.85.107 username='admin' password='admin' intf_type=loopback intf_name=20 intf_state=up
..
id: 5a564f58c4da5f37c54b29ba
status: succeeded
parameters: 
  intf_name: '20'
  intf_state: up
  intf_type: loopback
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    intf: true
    state: up
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceState: INFO     successfully connected to 10.24.85.107 to validate interface state

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.24.85.107 to validate interface state

    st2.actions.python.ValidateInterfaceState: INFO     Successfully validated interface loopback 20 state as up

    pyswitch.snmp.base.acl.Acl: INFO  Successfully validated interface loopback 20 state as up

    st2.actions.python.ValidateInterfaceState: INFO     closing connection to 10.24.85.107 after Validating interface state -- all done!

    pyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.24.85.107 after Validating interface state -- all done!

    '
  stdout: ''

	
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_state mgmt_ip=10.24.85.107 username='admin' password='admin' intf_type=port_channel intf_name=3 intf_state=down
..
id: 5a564e82c4da5f37c54b29b1
status: succeeded
parameters: 
  intf_name: '3'
  intf_state: down
  intf_type: port_channel
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    intf: true
    state: down
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceState: INFO     successfully connected to 10.24.85.107 to validate interface state

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.24.85.107 to validate interface state

    st2.actions.python.ValidateInterfaceState: INFO     Successfully validated interface port-channel 3 state as down

    pyswitch.snmp.base.acl.Acl: INFO  Successfully validated interface port-channel 3 state as down

    st2.actions.python.ValidateInterfaceState: INFO     closing connection to 10.24.85.107 after Validating interface state -- all done!

    pyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.24.85.107 after Validating interface state -- all done!

    '
  stdout: ''

 
 
