### PR TITLE
MLX-268: Fix the stale connection issue when DUT is rebooted

### DIFF
--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -79,7 +79,7 @@ class Device(object):
             try:
                 snmpdev = SNMPDevice(host=host, port=snmpport, version=snmpver, community=snmpv2c,
                                      username=v3user, authproto=v3auth, authkey=authpass,
-                                     privproto=v3priv, privkey=privpass)
+                                     privproto=v3priv, privkey=privpass, timeout=0.5, retries=1)
                 sysobj = str(snmpdev.get(MIB.mib_oid_map['sysObjectId']))
             except SNMPError:
                 """


### PR DESCRIPTION
- Fix stale connection issues
- Reduce snmp timeout and retries for performance improvement

```
Tests:

- Run a st2 action on mlx device.
- Rerun the action on same device and ensure connection is intact
- Reboot the MLX device
- Rerun the action on same device and ensure no Devicecommunication error.
```