### PR TITLE
CANDY-1028

### DIFF
--- a/pyswitch/raw/nos/base/acl/acl.py
+++ b/pyswitch/raw/nos/base/acl/acl.py
@@ -438,7 +438,7 @@ class Acl(SlxNosAcl):
             rpc_response = callback(config, handler='get')
             # xml.etree.ElementTree.dump(rpc_response)
             for elem in rpc_response.iter():
-                if elem.text == intf:
+                if elem.text == str(intf):
                     invalid_intf = False
                     break
             if invalid_intf:

--- a/pyswitch/raw/slxos/base/acl/acl.py
+++ b/pyswitch/raw/slxos/base/acl/acl.py
@@ -443,7 +443,7 @@ class Acl(SlxNosAcl):
             rpc_response = callback(config, handler='get')
             # xml.etree.ElementTree.dump(rpc_response)
             for elem in rpc_response.iter():
-                if elem.text == intf:
+                if elem.text == str(intf):
                     invalid_intf = False
                     break
             if invalid_intf:

--- a/pyswitch/raw/slxos/ver_17s/acl.py
+++ b/pyswitch/raw/slxos/ver_17s/acl.py
@@ -201,7 +201,7 @@ class Acl(NosBaseAcl):
             rpc_response = callback(config, handler='get')
             # xml.etree.ElementTree.dump(rpc_response)
             for elem in rpc_response.iter():
-                if elem.text == intf:
+                if elem.text == str(intf):
                     invalid_intf = False
                     break
             if invalid_intf:


### PR DESCRIPTION
stackstorm converts vlan or ve interface names to integers and hence
check fails against netconf response. typecasting interface name to str.