### PR TITLE
Fix for defects MLX-270, MLX-271,MLX-273, MLX-274,MLX-275

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -2490,15 +2490,17 @@ class Interface(BaseInterface):
             list.append(vlan)
         return list
 
-    @property
-    def get_vlan_port_map(self):
+    def get_vlan_port_map(self, untagged_ports):
         """ Get the list of ports associated with vlan
             Each element in the list is a dict containing vlan and list of interfaces
             [{'vlan':10, 'interfaces':[1/1, 2/1]}, {'vlan': 20, 'interfaces':[4/1]}]
         Args:
             None
+            untagged_ports (bool) - True/False
         Returns:
             List of dictionary of vlan->port mappings
+            if untagged_ports is True get the list of vlan->untagged port mappings
+            else get the list of vlan->tagged+untagged port mappings
         Examples:
             >>> import pyswitch.device
             >>> switches = ['10.24.85.107']
@@ -2512,12 +2514,16 @@ class Interface(BaseInterface):
             >>> for switch in switches:
             ...     conn = (switch, '22')
             ...     with pyswitch.device.Device(conn=conn, auth_snmp=auth_snmp) as dev:
-            ...         output = dev.interface.get_vlan_port_map
+            ...         output = dev.interface.get_vlan_port_map(untagged_ports=False)
+            ...         output = dev.interface.get_vlan_port_map(untagged_ports=True)
         """
         vlan_oid = SnmpMib.mib_oid_map['dot1qVlanStaticEntry']
         config = {}
         config['oid'] = vlan_oid
-        config['columns'] = {2: 'ports'}
+        if untagged_ports:
+            config['columns'] = {4: 'ports'}
+        else:
+            config['columns'] = {2: 'ports'}
         config['fetch_all'] = False
         vlan_table = self._callback(config, handler='snmp-walk')
         vlan_list = []
@@ -2587,12 +2593,14 @@ class Interface(BaseInterface):
         vlan_list = kwargs.pop('vlan_list')
         intf_name = kwargs.pop('intf_name')
         intf_type = kwargs.pop('intf_type')
-        # intf_mode = kwargs.pop('intf_mode', None)
+        intf_mode = kwargs.pop('intf_mode', None)
         all_true = True
         if not (intf_type == 'ethernet' or intf_type == 'port_channel'):
             raise ValueError('Invalid interface type for MLX')
         if intf_type == 'port_channel':
             lag_name = self.get_lag_id_name_map(str(intf_name))
+            if lag_name is None:
+                raise ValueError('Invalid interface name')
             # get the member ports of LAG
             ifid_name = self.get_port_channel_member_ports(lag_name)
             # pick a member of port-channel
@@ -2602,11 +2610,26 @@ class Interface(BaseInterface):
             else:
                 # Port-channel doesn't have any member ports
                 return False
-        vlan_port = self.get_vlan_port_map
+        vlan_port = self.get_vlan_port_map(untagged_ports=False)
+        untag_port = self.get_vlan_port_map(untagged_ports=True)
+        entry3 = {}
+        tagged_port = []
+        tagged_list = []
+        for entry1, entry2 in zip(vlan_port, untag_port):
+            s = set(entry2['interfaces'])
+            tagged_list = [x for x in entry1['interfaces'] if x not in s]
+            entry3 = {'vlan': entry1['vlan'],
+                      'interfaces': tagged_list}
+            tagged_port.append(entry3)
+        if intf_mode == 'access':
+            temp_vlan_port = untag_port
+        elif intf_mode == 'trunk':
+            temp_vlan_port = tagged_port
+
         for vlan_id in vlan_list:
             is_vlan_present = False
             is_intf_name_present = False
-            for entry in vlan_port:
+            for entry in temp_vlan_port:
                 if str(entry['vlan']) == str(vlan_id):
                     is_vlan_present = True
                     if intf_name in entry['interfaces']:
@@ -2624,6 +2647,7 @@ class Interface(BaseInterface):
             if is_vlan_present and not is_intf_name_present:
                 all_true = False
                 break
+
         return all_true
 
     def mac_move_detect_enable(self, **kwargs):


### PR DESCRIPTION

Logs:
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_vlan mgmt_ip=10.20.179.132 vlan_id=200 intf_type=port_channel intf_name=200 intf_mode=trunk
...
id: 5a5e2bd5c4da5f37c54b2b0a
status: succeeded
parameters: 
  intf_mode: trunk
  intf_name: '200'
  intf_type: port_channel
  mgmt_ip: 10.20.179.132
  vlan_id: '200'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.20.179.132 to validate interface vlan

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    pyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    '
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_vlan mgmt_ip=10.20.179.132 vlan_id=200 intf_type=port_channel intf_name=200 intf_mode=access 
..
id: 5a5e4fa1c4da5f37c54b2b13
status: succeeded
parameters: 
  intf_mode: access
  intf_name: '200'
  intf_type: port_channel
  mgmt_ip: 10.20.179.132
  vlan_id: '200'
result: 
  exit_code: 0
  result:
    vlan: false
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.20.179.132 to validate interface vlan

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: INFO     closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    pyswitch.snmp.base.acl.Acl: INFO  closing connection to 10.20.179.132 after Validating interface vlan -- all done!

    '
  stdout: ''

  stdout: ''
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.validate_interface_vlan mgmt_ip=10.20.179.132 vlan_id=200 intf_type=ethernet intf_name=2/13 intf_mode=access 
..
id: 5a5e504ec4da5f37c54b2b19
status: failed
parameters: 
  intf_mode: access
  intf_name: 2/13
  intf_type: ethernet
  mgmt_ip: 10.20.179.132
  vlan_id: '200'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.ValidateInterfaceVlan: INFO     successfully connected to 10.20.179.132 to validate interface vlan

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to validate interface vlan

    st2.actions.python.ValidateInterfaceVlan: ERROR    Interface ethernet 2/13 not present on the device

    pyswitch.snmp.base.acl.Acl: ERROR  Interface ethernet 2/13 not present on the device

    '
  stdout: ''


+-------------+--------------------------------------------------------------+
| Property    | Value                                                        |
+-------------+--------------------------------------------------------------+
| id          | 5983df0bc4da5f3e3a465bc6                                     |
| uid         | action:network_essentials:validate_interface_vlan            |
| ref         | network_essentials.validate_interface_vlan                   |
| pack        | network_essentials                                           |
| name        | validate_interface_vlan                                      |
| description | Validate port channel or physical interface belongs to the   |
|             | specified VLAN                                               |
| enabled     | True                                                         |
| entry_point | validate_interface_vlan.py                                   |
| runner_type | run-python                                                   |
| parameters  | {                                                            |
|             |     "username": {                                            |
|             |         "position": 1,                                       |
|             |         "type": "string",                                    |
|             |         "description": "Login user name to connect to the    |
|             | device"                                                      |
|             |     },                                                       |
|             |     "intf_type": {                                           |
|             |         "position": 4,                                       |
|             |         "enum": [                                            |
|             |             "gigabitethernet",                               |
|             |             "tengigabitethernet",                            |
|             |             "fortygigabitethernet",                          |
|             |             "hundredgigabitethernet",                        |
|             |             "port_channel",                                  |
|             |             "ethernet"                                       |
|             |         ],                                                   |
|             |         "type": "string",                                    |
|             |         "description": "Interface type",                     |
|             |         "required": true                                     |
|             |     },                                                       |
|             |     "mgmt_ip": {                                             |
|             |         "position": 0,                                       |
|             |         "required": true,                                    |
|             |         "type": "string",                                    |
|             |         "description": "Management IP address of the target  |
|             | device"                                                      |
|             |     },                                                       |
|             |     "intf_mode": {                                           |
|             |         "default": "access",                                 |
|             |         "position": 6,                                       |
|             |         "enum": [                                            |
|             |             "trunk",                                         |
|             |             "access"                                         |
|             |         ],                                                   |
|             |         "type": "string",                                    |
|             |         "description": "Interface mode"                      |
|             |     },                                                       |
|             |     "intf_name": {                                           |
|             |         "position": 5,                                       |
|             |         "required": true,                                    |
|             |         "type": "string",                                    |
|             |         "description": "Interface name, for VDX in 3-tuple   |
|             | format (24/0/1), SLX/NI in 2-tuple format (24/1) or Port-    |
|             | channel number <1-6144>, for NI <1-256>."                    |
|             |     },                                                       |
|             |     "password": {                                            |
|             |         "position": 2,                                       |
|             |         "secret": true,                                      |
|             |         "type": "string",                                    |
|             |         "description": "Login password to connect to the     |
|             | device"                                                      |
|             |     },                                                       |
|             |     "vlan_id": {                                             |
|             |         "position": 3,                                       |
|             |         "required": true,                                    |
|             |         "type": "string",                                    |
|             |         "description": "Single VLAN or range of VLANs, for   |
|             | example 2 or 3-9"                                            |
|             |     }                                                        |
|             | }                                                            |
| notify      |                                                              |
| tags        | [                                                            |
|             |     {                                                        |
|             |         "name": "group",                                     |
|             |         "value": "Validate Edge Ports"                       |
|             |     },                                                       |
|             |     {                                                        |
|             |         "name": "suite",                                     |
|             |         "value": "DCFABRIC"                                  |
|             |     }                                                        |
|             | ]                                                            |
+-------------+--------------------------------------------------------------+
ubuntu@st2vagrant:~/bash_scripts$ 
