### PR TITLE
Changed regex search to remove access vlan for both po and ethernet

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -925,7 +925,7 @@ class Interface(BaseInterface):
 
         cli_cmd = 'show interface ' + ' ' + int_type + ' ' + name
 
-        pre_config_pat = r'Member of VLAN (\d+) \(untagged\)'
+        pre_config_pat = r'VLAN (\d+) \(untagged\)'
         get_vlan = 0
         try:
             cli_output = callback(cli_cmd, handler='cli-get')


### PR DESCRIPTION
MLX gives different output for same "show interface ethernet <>" command when a interface part of port-channel, so changed regex search to be common for both

 st2 run network_essentials.remove_switchport_access_vlan mgmt_ip=10.20.179.132 intf_type=port_channel intf_name=200 vlan_id=200
.....
id: 5a5fce17c4da5f5f037f199d
status: succeeded
parameters: 
  intf_name: '200'
  intf_type: port_channel
  mgmt_ip: 10.20.179.132
  vlan_id: '200'
result: 
  exit_code: 0
  result: true
  stderr: 'st2.actions.python.RemoveSwitchPort: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.RemoveSwitchPort: INFO     successfully connected to 10.20.179.132 to remove access vlan on Interface

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to remove access vlan on Interface

    '
  stdout: ''
(network_essentials) vagrant (remove_switchport_access) network_essentials
$ st2 run network_essentials.remove_switchport_access_vlan mgmt_ip=10.20.179.132 intf_type=ethernet intf_name=5/4 vlan_id=300
....
id: 5a5fcf91c4da5f5f037f19a0
status: succeeded
parameters: 
  intf_name: 5/4
  intf_type: ethernet
  mgmt_ip: 10.20.179.132
  vlan_id: '300'
result: 
  exit_code: 0
  result: true
  stderr: 'st2.actions.python.RemoveSwitchPort: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)

    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.RemoveSwitchPort: INFO     successfully connected to 10.20.179.132 to remove access vlan on Interface

    pyswitch.snmp.base.acl.Acl: INFO  successfully connected to 10.20.179.132 to remove access vlan on Interface

    '
  stdout: ''
(network_essentials) vagrant (remove_switch