### PR TITLE
Maximum IP MTU value changed for MLX

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -69,14 +69,14 @@ class Interface(BaseInterface):
     def l3_mtu_const(self):
         # TBD change below defaults
         minimum_mtu = 576
-        maximum_mtu = 8982
+        maximum_mtu = 9198
         return (minimum_mtu, maximum_mtu)
 
     @property
     def l3_ipv6_mtu_const(self):
         # TBD change below defaults
         minimum_mtu = 1280
-        maximum_mtu = 8982
+        maximum_mtu = 9198
         return (minimum_mtu, maximum_mtu)
 
     @property
@@ -1298,20 +1298,20 @@ class Interface(BaseInterface):
             raise ValueError(
                 "Incorrect mtu value %s-%s" %
                 (minimum_mtu, maximum_mtu))
+        cli_arr = []
+        cli_arr.append('interface ' + int_type + ' ' + name)
         if version == 4:
-            mtu_config = (mtu_oid, mtu)
-            callback(mtu_config, 'snmp-set')
+            cli_arr.append('ip mtu ' + str(mtu))
         else:
-            cli_arr = []
-            cli_arr.append('interface ' + int_type + ' ' + name)
             cli_arr.append('ipv6 mtu ' + str(mtu))
-            try:
-                cli_res = callback(cli_arr, handler='cli-set')
-                pyswitch.utilities.check_mlx_cli_set_error(cli_res)
-                return True
-            except Exception as error:
-                reason = error.message
-                raise ValueError('Failed to set IPv6 MTU %s' % (reason))
+
+        try:
+            cli_res = callback(cli_arr, handler='cli-set')
+            pyswitch.utilities.check_mlx_cli_set_error(cli_res)
+            return True
+        except Exception as error:
+            reason = error.message
+            raise ValueError('Failed to set IPv%s MTU %s' % (version, reason))
 
     def vrf(self, **kwargs):
         """Create a vrf.

--- a/pyswitch/snmp/mlx/base/system.py
+++ b/pyswitch/snmp/mlx/base/system.py
@@ -99,7 +99,7 @@ class System(BaseSystem):
             Args:
 
                 mtu (str): Value between 576  and 9198 for ipv4
-                           Value between 1280 - 8982 for ipv6
+                           Value between 1280 - 9198 for ipv6
                 version (int) : 4 or 6
                 callback (function): A function executed upon completion of
                     the method.
@@ -139,7 +139,7 @@ class System(BaseSystem):
 
         if version is 6:
             minimum_mtu = 1280
-            maximum_mtu = 8982
+            maximum_mtu = 9198
             if int(mtu) < minimum_mtu or int(mtu) > maximum_mtu:
                 raise ValueError(
                     "Incorrect mtu value, Valid Range %s-%s" %
@@ -149,7 +149,7 @@ class System(BaseSystem):
 
         try:
             cli_res = callback(cli_arr, handler='cli-set')
-            error = re.search(r'Error:(.+)', cli_res)
+            error = re.search(r'Error (.+)', cli_res)
             invalid_input = re.search(r'Invalid input', cli_res)
             if error:
                 raise ValueError("%s" % error.group(0))


### PR DESCRIPTION
$ st2 run network_essentials.set_l3_system_mtu mgmt_ip=10.24.85.107 username=admin password=admin mtu_size=9198 afi=ipv6
.......
id: 5a66554fc4da5f5f037f19cd
status: succeeded
parameters: 
  afi: ipv6
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    result: true
  stderr: 'st2.actions.python.set_l3_system_mtu: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.set_l3_system_mtu: INFO     successfully connected to 10.24.85.107 to set system IP mtu

    st2.actions.python.set_l3_system_mtu: INFO     configuring mtu_size 9198 on the device

    st2.actions.python.set_l3_system_mtu: INFO     Successfully  set system IP mtu_size 9198 on the device

    st2.actions.python.set_l3_system_mtu: INFO     closing connection to 10.24.85.107 after configuring system IP mtu -- all done!

    '
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_system_mtu mgmt_ip=10.24.85.107 username=admin password=admin mtu_size=9198 afi=ipv4
...
id: 5a6659b1c4da5f5f037f19d0
status: succeeded
parameters: 
  afi: ipv4
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    result: true
  stderr: 'st2.actions.python.set_l3_system_mtu: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.set_l3_system_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.set_l3_system_mtu: INFO     successfully connected to 10.24.85.107 to set system IP mtu

    st2.actions.python.set_l3_system_mtu: INFO     configuring mtu_size 9198 on the device

    st2.actions.python.set_l3_system_mtu: INFO     Successfully  set system IP mtu_size 9198 on the device

    st2.actions.python.set_l3_system_mtu: INFO     closing connection to 10.24.85.107 after configuring system IP mtu -- all done!

    '
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_mtu mgmt_ip=10.24.85.107 username=admin password=admin intf_type=ve intf_name=240 mtu_size=8982 afi=ipv6
...
id: 5a6659e5c4da5f5f037f19d3
status: succeeded
parameters: 
  afi: ipv6
  intf_name:
  - 240
  intf_type: ve
  mgmt_ip: 10.24.85.107
  mtu_size: 8982
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    result: true
  stderr: 'st2.actions.python.set_l3_mtu: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.set_l3_mtu: INFO     successfully connected to 10.24.85.107 to set mtu

    st2.actions.python.set_l3_mtu: INFO     configuring mtu_size 8982 on int-type - ve int-name- 240

    st2.actions.python.set_l3_mtu: INFO     Successfully  set  mtu_size 8982 on int ve 240

    st2.actions.python.set_l3_mtu: INFO     closing connection to 10.24.85.107 after configuring L3 mtu on interface-- all done!

    '
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_mtu mgmt_ip=10.24.85.107 username=admin password=admin intf_type=ve intf_name=240 mtu_size=9198 afi=ipv6
...
id: 5a665a0cc4da5f5f037f19d6
status: succeeded
parameters: 
  afi: ipv6
  intf_name:
  - 240
  intf_type: ve
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    result: true
  stderr: 'st2.actions.python.set_l3_mtu: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.set_l3_mtu: INFO     successfully connected to 10.24.85.107 to set mtu

    st2.actions.python.set_l3_mtu: INFO     configuring mtu_size 9198 on int-type - ve int-name- 240

    st2.actions.python.set_l3_mtu: INFO     Successfully  set  mtu_size 9198 on int ve 240

    st2.actions.python.set_l3_mtu: INFO     closing connection to 10.24.85.107 after configuring L3 mtu on interface-- all done!

    '
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_mtu mgmt_ip=10.24.85.107 username=admin password=admin intf_type=ve intf_name=240 mtu_size=9198 afi=ipv4
...
id: 5a665a26c4da5f5f037f19d9
status: failed
parameters: 
  afi: ipv4
  intf_name:
  - 240
  intf_type: ve
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 1
  result: None
  stderr: "st2.actions.python.set_l3_mtu: DEBUG    Creating new Client object.\nNo handlers could be found for logger \"st2.st2common.services.access\"\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)\nst2.actions.python.set_l3_mtu: INFO     successfully connected to 10.24.85.107 to set mtu\nst2.actions.python.set_l3_mtu: INFO     configuring mtu_size 9198 on int-type - ve int-name- 240\nst2.actions.python.set_l3_mtu: ERROR    Cannot set L3 mtu on interface ve 240 due to Failed to set IPv6 MTU Error - 9198 not between 576 and 9194\nst2.actions.python.set_l3_mtu: ERROR    Error encountered on 10.24.85.107 due to Failed to set IPv6 MTU Error - 9198 not between 576 and 9194\nTraceback (most recent call last):\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 1013, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 31, in switch_operation\n    ip_version=ip_version)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 60, in _set_l3_mtu\n    raise ValueError(e.message)\nValueError: Failed to set IPv6 MTU Error - 9198 not between 576 and 9194\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 275, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 163, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 13, in run\n    output = self.switch_operation(afi, intf_type, mtu_size, intf_name)\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 1013, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 31, in switch_operation\n    ip_version=ip_version)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 60, in _set_l3_mtu\n    raise ValueError(e.message)\nValueError: Failed to set IPv6 MTU Error - 9198 not between 576 and 9194\n"
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_mtu mgmt_ip=10.24.85.107 username=admin password=admin intf_type=ve intf_name=240 mtu_size=9198 afi=ipv4
...
id: 5a665b21c4da5f5f037f19dc
status: failed
parameters: 
  afi: ipv4
  intf_name:
  - 240
  intf_type: ve
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 1
  result: None
  stderr: "st2.actions.python.set_l3_mtu: DEBUG    Creating new Client object.\nNo handlers could be found for logger \"st2.st2common.services.access\"\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)\nst2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)\nst2.actions.python.set_l3_mtu: INFO     successfully connected to 10.24.85.107 to set mtu\nst2.actions.python.set_l3_mtu: INFO     configuring mtu_size 9198 on int-type - ve int-name- 240\nst2.actions.python.set_l3_mtu: ERROR    Cannot set L3 mtu on interface ve 240 due to Failed to set IPv4 MTU Error - 9198 not between 576 and 9194\nst2.actions.python.set_l3_mtu: ERROR    Error encountered on 10.24.85.107 due to Failed to set IPv4 MTU Error - 9198 not between 576 and 9194\nTraceback (most recent call last):\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 1013, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 31, in switch_operation\n    ip_version=ip_version)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 60, in _set_l3_mtu\n    raise ValueError(e.message)\nValueError: Failed to set IPv4 MTU Error - 9198 not between 576 and 9194\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 275, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 163, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 13, in run\n    output = self.switch_operation(afi, intf_type, mtu_size, intf_name)\n  File \"/home/vagrant/bwc/network_essentials/actions/ne_base.py\", line 1013, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 31, in switch_operation\n    ip_version=ip_version)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_l3_mtu.py\", line 60, in _set_l3_mtu\n    raise ValueError(e.message)\nValueError: Failed to set IPv4 MTU Error - 9198 not between 576 and 9194\n"
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ st2 run network_essentials.set_l3_mtu mgmt_ip=10.24.85.107 username=admin password=admin intf_type=ethernet intf_name=4/5 mtu_size=9198 afi=ipv4
...
id: 5a66680dc4da5f5f037f19df
status: succeeded
parameters: 
  afi: ipv4
  intf_name:
  - 4/5
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  mtu_size: 9198
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    result: true
  stderr: 'st2.actions.python.set_l3_mtu: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.set_l3_mtu: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.set_l3_mtu: INFO     successfully connected to 10.24.85.107 to set mtu

    st2.actions.python.set_l3_mtu: INFO     configuring mtu_size 9198 on int-type - ethernet int-name- 4/5

    st2.actions.python.set_l3_mtu: INFO     Successfully  set  mtu_size 9198 on int ethernet 4/5

    st2.actions.python.set_l3_mtu: INFO     closing connection to 10.24.85.107 after configuring L3 mtu on interface-- all done!

    '
  stdout: ''
(network_essentials) vagrant (ip_mtu *) network_essentials
$ make lint
