### PR TITLE
CANDY-1026

### DIFF
--- a/pyswitch/raw/slx_nos/acl/macacl.py
+++ b/pyswitch/raw/slx_nos/acl/macacl.py
@@ -162,6 +162,35 @@ class MacAcl(AclParamParser):
                          " Specify Integer or \'arp\', " "\'fcoe\', \'ipv4\'"
                          .format(ethertype))
 
+    def parse_slx_ethertype(self, **kwargs):
+        """
+        parse the ethertype param
+        Args:
+            kwargs contains:
+                ethertype(string): EtherType, can be 'arp', 'fcoe', 'ipv4' or
+                    custom value between 1536 and 65535.
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'ethertype' not in kwargs or not kwargs['ethertype']:
+            return None
+
+        ethertype = kwargs['ethertype']
+
+        if ethertype in ['arp', 'fcoe', 'ipv4', 'ipv6']:
+            return ethertype
+
+        if ethertype.isdigit():
+            if int(ethertype) >= 1536 or int(ethertype) <= 65535:
+                return ethertype
+
+        raise ValueError("The ethertype value {} is invalid."
+                         " Specify Integer or \'arp\', " "\'fcoe\', \'ipv4\'"
+                         " \'ipv6\'".format(ethertype))
+
     def parse_vlan_id(self, vlan):
 
         if vlan == "any":

--- a/pyswitch/raw/slxos/base/acl/acl.py
+++ b/pyswitch/raw/slxos/base/acl/acl.py
@@ -397,7 +397,7 @@ class Acl(SlxNosAcl):
         user_data['source'] = self.mac.parse_source(**kwargs)
         user_data['dst'] = self.mac.parse_dst(**kwargs)
         user_data['vlan_tag_format'] = self.mac.parse_vlan_tag_format(**kwargs)
-        user_data['ethertype'] = self.mac.parse_ethertype(**kwargs)
+        user_data['ethertype'] = self.mac.parse_slx_ethertype(**kwargs)
         user_data['vlan'] = self.mac.parse_vlan(**kwargs)
         user_data['arp_guard'] = self.mac.parse_arp_guard(**kwargs)
         user_data['pcp'] = self.mac.parse_pcp(**kwargs)


### PR DESCRIPTION
Fusion platform suports ethertype ipv6 whereas vdx doesn't. The earlier
implementation was influenced by vdx. This change allows ipv6 ethertype
for fusion device type.