### PR TITLE
MLX-162

### DIFF
--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -419,8 +419,6 @@ class Acl(object):
 
         for line in output.split('\n'):
             if 'Invalid input ' in line or 'error' in line.lower() or \
-                    'No L2  inbound ACL' in line or \
-                    'No L2 outbound ACL' in line or \
                     'Incomplete command' in line or \
                     'cannot be used as an ACL name' in line or \
                     'name can\'t be more than 255 characters' in line:

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -538,9 +538,9 @@ class Acl(BaseAcl):
             regex = re.compile('no.*bound acl', re.IGNORECASE)
             m = regex.search(output)
             if m:
-                raise ValueError("remove_acl failed for interface {}. "
-                                 "acl removed successfully from interfaces {}"
-                                 .format(intf, str(processed_interfaces)))
+                raise ValueError("Acl removed from interfaces {}, "
+                                 "but failed remove_acl for interface {}"
+                                 .format(str(processed_interfaces), intf))
             self._process_cli_output(inspect.stack()[0][3], config, output)
             processed_interfaces.append(intf)
 

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -485,7 +485,6 @@ class Acl(BaseAcl):
         """
         params_validator.validate_params_mlx_remove_acl(**parameters)
 
-        cli_arr = []
         acl_name = parameters['acl_name']
         intf_type = parameters['intf_type']
         intf_name = parameters.pop('intf_name', None)
@@ -518,7 +517,9 @@ class Acl(BaseAcl):
             output = self._callback([config], handler='cli-set')
             self._process_cli_output(inspect.stack()[0][3], config, output)
 
+        processed_interfaces = []
         for intf in intf_name:
+            cli_arr = []
             cmd = acl_template.interface_submode_template
             t = jinja2.Template(cmd)
             config = t.render(intf_name=intf, **parameters)
@@ -533,8 +534,17 @@ class Acl(BaseAcl):
 
             cli_arr.append('exit')
 
-        output = self._callback(cli_arr, handler='cli-set')
-        return self._process_cli_output(inspect.stack()[0][3], config, output)
+            output = self._callback(cli_arr, handler='cli-set')
+            regex = re.compile('no.*bound acl', re.IGNORECASE)
+            m = regex.search(output)
+            if m:
+                raise ValueError("remove_acl failed for interface {}. "
+                                 "acl removed successfully from interfaces {}"
+                                 .format(intf, str(processed_interfaces)))
+            self._process_cli_output(inspect.stack()[0][3], config, output)
+            processed_interfaces.append(intf)
+
+        return 'remove_acl : Successful'
 
     def add_ipv4_rule_acl(self, **parameters):
         """


### PR DESCRIPTION
This change process each interface response separately and also uses
regex to determine failure conditions.

st2 run network_essentials.remove_acl mgmt_ip=10.37.73.148 username=admin password=admin intf_type=ethernet intf_name="1/2,1/1" acl_name=candy-868 acl_direction=in

output-1>>>
    st2.actions.python.Remove_Acl: INFO     Removing ACL candy-868 on int-type - ethernet int-name- [u''1/2'', u''1/1'']
    st2.actions.python.Remove_Acl: INFO     remove_acl : Successful

output-2>>>
ValueError: remove_acl failed for interface 1/1. acl removed successfully from interfaces [u'1/2']\n"

