### PR TITLE
Fix for MLX-282

### DIFF
--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -297,10 +297,10 @@ class SnmpCliDevice(AbstractDevice):
                     value = self._proxied.cli_execution(handler, self.host, call)
                 finally:
                     self._proxied.netmiko_release()
-        except (SNMPError) as error:
-            raise DeviceCommError(error)
+        except SNMPError:
+            raise
         except Exception:
-            raise DeviceCommError
+            raise
 
         return value
 

--- a/pyswitch/snmp/base/interface.py
+++ b/pyswitch/snmp/base/interface.py
@@ -118,7 +118,7 @@ class Interface(object):
 
         except Exception as error:
             reason = error.message
-            raise ValueError('Failed to delete VLAN %d due to %s', vlan_id, reason)
+            raise ValueError(reason)
 
     def get_vlan_int(self, vlan_id):
         """


### PR DESCRIPTION
snmp-set/get/walk was not raising an exception for failure cases. Raise the exception.

Logs:
ubuntu@st2vagrant:~/bash_scripts$ st2 run network_essentials.delete_vlan mgmt_ip=10.18.121.2 username=User_test password=password vlan_id=10
.....
id: 5a750471c4da5f37c54b2b61
status: failed
parameters: 
  mgmt_ip: 10.18.121.2
  password: '********'
  username: User_test
  vlan_id: '10'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.18.121.2.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.18.121.2.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.18.121.2.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.18.121.2.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.18.121.2.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.18.121.2 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 10

    st2.actions.python.DeleteVlan: ERROR    VLAN 10 deletion failed due to No SNMP response received before timeout

    '
  stdout: ''