### PR TITLE
L2 bulking support added for action add_or_remove_l2_acl_rule.

### DIFF
--- a/pyswitch/raw/base/acl.py
+++ b/pyswitch/raw/base/acl.py
@@ -433,3 +433,51 @@ class Acl(object):
                                                             seq_id="10,30-40")
         """
         return
+
+    @abc.abstractmethod
+    def add_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Add ACL rule to an existing L2 ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            acl_rules (array): List of ACL sequence rules.
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='mac')
+            >>>     print dev.acl.add_mac_acl_rule(acl_name='Acl_1', seq_id=20,
+                                                   action='permit',
+                                                   source='host',
+                                                   srchost='2222.2222.2222')
+        """
+        return
+
+    @abc.abstractmethod
+    def delete_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Delete ACL rules from MAC ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            seq_id(string): Range of ACL sequences seq_id="10,30-40"
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='ip')
+            >>>     print dev.acl.delete_l2_acl_rule_bulk(acl_name='Acl_1',
+                                                          seq_id="10,30-40")
+        """
+        return

--- a/pyswitch/raw/nos/base/acl/acl_template.py
+++ b/pyswitch/raw/nos/base/acl/acl_template.py
@@ -550,3 +550,66 @@ get_interface_by_name = """
       {% endif %}
   </get-config>
 """
+
+acl_rule_mac_bulk = """
+<config>
+  <mac xmlns="urn:brocade.com:mgmt:brocade-mac-access-list">
+    <access-list>
+      <{{acl_type}}>
+        <name>{{acl_name}}</name>
+        {% if acl_type == "extended" %}
+          <hide-mac-acl-ext>
+        {% else %}
+          <hide-mac-acl-std>
+        {% endif %}
+
+        {% for ud in user_data_list %}
+          <seq>
+            <seq-id>{{ud.seq_id}}</seq-id>
+            <action>{{ud.action}}</action>
+
+            <source>{{ud.source.source}}</source>
+            {% if ud.source.source != "any" %}
+              {% if ud.source.source == "host" %}
+                <srchost>{{ud.source.srchost}}</srchost>
+              {% else %}
+                <src-mac-addr-mask>{{ud.source.mask}}</src-mac-addr-mask>
+              {% endif %}
+            {% endif %}
+
+            {% if acl_type == "extended" %}
+
+              <dst>{{ud.dst.dst}}</dst>
+              {% if ud.dst.dst != "any" %}
+                {% if ud.dst.dst == "host" %}
+                  <dsthost>{{ud.dst.dsthost}}</dsthost>
+                {% else %}
+                  <dst-mac-addr-mask>{{ud.dst.mask}}</dst-mac-addr-mask>
+                {% endif %}
+              {% endif %}
+
+              {% if ud.ethertype is not none %}
+                <ethertype>{{ud.ethertype}}</ethertype>
+              {% endif %}
+
+              {% if ud.vlan is not none %}
+                <vlan>{{ud.vlan}}</vlan>
+              {% endif %}
+
+            {% endif %}
+
+            {% if ud.count is not none %} <count></count> {% endif %}
+            {% if ud.log is not none %}<log></log> {% endif %}
+          </seq>
+        {% endfor %}
+
+        {% if acl_type == "extended" %}
+          </hide-mac-acl-ext>
+        {% else %}
+          </hide-mac-acl-std>
+        {% endif %}
+      </{{acl_type}}>
+    </access-list>
+  </mac>
+</config>
+"""

--- a/pyswitch/raw/slx_nos/acl/acl.py
+++ b/pyswitch/raw/slx_nos/acl/acl.py
@@ -34,6 +34,7 @@ class SlxNosAcl(BaseAcl):
     """
     RULE_CHUNK_SIZE = 200
     IPV6_RULE_CHUNK_SIZE = 1
+    MAC_RULE_CHUNK_SIZE = 1
 
     def __init__(self, callback):
         """
@@ -466,6 +467,59 @@ class SlxNosAcl(BaseAcl):
 
         for chunk in chunks:
             t = jinja2.Template(acl_template.acl_rule_ipx_delete_bulk)
+            config = t.render(address_type=address_type,
+                              acl_type=acl_type,
+                              acl_name=acl_name,
+                              user_data_list=chunk)
+            config = ' '.join(config.split())
+
+            try:
+                callback(config)
+            except Exception as rpc_err:
+                raise ValueError(rpc_err)
+        return True
+
+    def delete_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Delete ACL rules from MAC ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            seq_id(string): Range of ACL sequences seq_id="10,30-40"
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='ip')
+            >>>     print dev.acl.delete_l2_acl_rule_bulk(acl_name='Acl_1',
+                                                          seq_id="10,30-40")
+        """
+        # Validate required and accepted parameters
+        params_validator. \
+            validate_params_nos_delete_add_or_remove_l2_acl_rule(**kwargs)
+
+        # Parse params
+        acl_name = self.ap.parse_acl_name(**kwargs)
+        callback = kwargs.pop('callback', self._callback)
+
+        acl = self._get_acl_info(acl_name, get_seqs=True)
+        acl_type = acl['type']
+        address_type = acl['protocol']
+        seq_range = self.ap.parse_seq_id_by_range(acl['seq_ids'], **kwargs)
+        user_data_list = [{'seq_id': seq_id} for seq_id in seq_range]
+
+        # send the rules in a chunk of Acl.MAC_RULE_CHUNK_SIZE
+        chunks = [user_data_list[i:i + SlxNosAcl.MAC_RULE_CHUNK_SIZE]
+                  for i in xrange(0, len(user_data_list),
+                                  SlxNosAcl.MAC_RULE_CHUNK_SIZE)]
+
+        for chunk in chunks:
+            t = jinja2.Template(acl_template.acl_rule_mac_delete_bulk)
             config = t.render(address_type=address_type,
                               acl_type=acl_type,
                               acl_name=acl_name,

--- a/pyswitch/raw/slx_nos/acl/acl_template.py
+++ b/pyswitch/raw/slx_nos/acl/acl_template.py
@@ -187,3 +187,32 @@ acl_rule_ipx_delete_bulk = """
   </{{address_type}}-acl>
 </config>
 """
+
+acl_rule_mac_delete_bulk = """
+<config>
+  <mac xmlns="urn:brocade.com:mgmt:brocade-mac-access-list">
+    <access-list>
+      <{{acl_type}}>
+        <name>{{acl_name}}</name>
+        {% if acl_type == "extended" %}
+          <hide-mac-acl-ext>
+        {% else %}
+          <hide-mac-acl-std>
+        {% endif %}
+
+        {% for ud in user_data_list %}
+          <seq operation="delete">
+            <seq-id>{{ud.seq_id}}</seq-id>
+          </seq>
+        {% endfor %}
+
+        {% if acl_type == "extended" %}
+          </hide-mac-acl-ext>
+        {% else %}
+          </hide-mac-acl-std>
+        {% endif %}
+      </{{acl_type}}>
+    </access-list>
+  </mac>
+</config>
+"""

--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -479,3 +479,33 @@ def validate_params_nos_add_ipv6_std_rule_acl(**parameters):
         if set(unaccepted_params) != set(st2_specific_params):
             raise ValueError("unaccepted parameters provided: {}"
                              .format(unaccepted_params))
+
+
+def validate_params_nos_add_or_remove_l2_acl_std_rule(**parameters):
+
+    required_params = ['acl_name', 'source', 'action']
+    accepted_params = ['acl_name', 'srchost', 'count', 'log', 'seq_id',
+                       'source', 'src_mac_addr_mask', 'action']
+    st2_specific_params = ['arp_guard', 'copy_sflow', 'mirror']
+
+    received_params = [k for k, v in parameters.iteritems() if v]
+
+    absent_required = list(set(required_params) - set(received_params))
+    if len(absent_required) > 0:
+        raise ValueError("missing required parameters: {}"
+                         .format(absent_required))
+
+    if 'arp_guard' in received_params and parameters['arp_guard'] != 'False':
+        raise ValueError("unaccepted parameters provided: arp_guard")
+
+    if 'copy_sflow' in received_params and parameters['copy_sflow'] != 'False':
+        raise ValueError("unaccepted parameters provided: copy_sflow")
+
+    if 'mirror' in received_params and parameters['mirror'] != 'False':
+        raise ValueError("unaccepted parameters provided: mirror")
+
+    unaccepted_params = list(set(received_params) - set(accepted_params))
+    if len(unaccepted_params) > 0:
+        if set(unaccepted_params) != set(st2_specific_params):
+            raise ValueError("unaccepted parameters provided: {}"
+                             .format(unaccepted_params))

--- a/pyswitch/raw/slxos/base/acl/acl.py
+++ b/pyswitch/raw/slxos/base/acl/acl.py
@@ -778,3 +778,27 @@ class Acl(SlxNosAcl):
                                                          chunk[0]['seq_id'])
 
         return True
+
+    def add_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Add ACL rule to an existing L2 ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            acl_rules (array): List of ACL sequence rules.
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='mac')
+            >>>     print dev.acl.add_mac_acl_rule(acl_name='Acl_1', seq_id=20,
+                                                   action='permit',
+                                                   source='host',
+                                                   srchost='2222.2222.2222')
+        """
+        raise ValueError('add_l2_acl_rule_bulk not supported on slx yet')

--- a/pyswitch/raw/slxos/ver_17s/acl.py
+++ b/pyswitch/raw/slxos/ver_17s/acl.py
@@ -373,3 +373,27 @@ class Acl(NosBaseAcl):
         user_data['traffic_type'] = self._app.parse_traffic_type(**kwargs)
 
         return user_data
+
+    def add_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Add ACL rule to an existing L2 ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            acl_rules (array): List of ACL sequence rules.
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='mac')
+            >>>     print dev.acl.add_mac_acl_rule(acl_name='Acl_1', seq_id=20,
+                                                   action='permit',
+                                                   source='host',
+                                                   srchost='2222.2222.2222')
+        """
+        raise ValueError('add_l2_acl_rule_bulk not supported on slx 17s yet')

--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -438,3 +438,51 @@ class Acl(object):
         if len(unsupported_params) > 0:
             raise ValueError("unsupported parameters provided: {}"
                              .format(unsupported_params))
+
+    @abc.abstractmethod
+    def add_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Add ACL rule to an existing L2 ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            acl_rules (array): List of ACL sequence rules.
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='mac')
+            >>>     print dev.acl.add_mac_acl_rule(acl_name='Acl_1', seq_id=20,
+                                                   action='permit',
+                                                   source='host',
+                                                   srchost='2222.2222.2222')
+        """
+        return
+
+    @abc.abstractmethod
+    def delete_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Delete ACL rules from MAC ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            seq_id(string): Range of ACL sequences seq_id="10,30-40"
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='ip')
+            >>>     print dev.acl.delete_l2_acl_rule_bulk(acl_name='Acl_1',
+                                                          seq_id="10,30-40")
+        """
+        return

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -1320,3 +1320,27 @@ class Acl(BaseAcl):
         output = self._callback(cli_arr, handler='cli-set')
         return self._process_cli_output(inspect.stack()[0][3],
                                         str(cli_arr), output)
+
+    def add_l2_acl_rule_bulk(self, **kwargs):
+        """
+        Add ACL rule to an existing L2 ACL.
+        Args:
+            acl_name (str): Name of the access list.
+            acl_rules (array): List of ACL sequence rules.
+        Returns:
+            True, False or None for Success, failure and no-change respectively
+            for each seq_ids.
+
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.create_acl(acl_name='Acl_1',
+                                             acl_type='standard',
+                                             address_type='mac')
+            >>>     print dev.acl.add_mac_acl_rule(acl_name='Acl_1', seq_id=20,
+                                                   action='permit',
+                                                   source='host',
+                                                   srchost='2222.2222.2222')
+        """
+        raise ValueError('add_l2_acl_rule_bulk not supported on mlx yet')


### PR DESCRIPTION
NOTE: This only avaliable to NOS device type as part of this commit.

Following cases executed as part of this commit:

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.37.18.151 acl_name=ext-l2-acl-bulk acl_rules='[{"action": "deny", "source": "1111.1111.1111", "src_mac_addr_mask": "1111.1111.1111", "dst": "1111.1111.1111", "dst_mac_addr_mask": "1111.1111.1111"}, {"action": "deny", "source": "1111.1111.1112", "src_mac_addr_mask": "1111.1111.1112", "dst": "1111.1111.1112", "dst_mac_addr_mask": "1111.1111.1112"}, {"action": "deny", "source": "1111.1111.1113", "src_mac_addr_mask": "1111.1111.1113", "dst": "1111.1111.1113", "dst_mac_addr_mask": "1111.1111.1113"}]'

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.37.18.151 acl_name=ext-l2-acl-bulk delete=True seq_id=30

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.37.18.151 acl_name=ext-l2-acl-bulk delete=True seq_id="all"

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.37.18.151 acl_name=ext-l2-acl-bulk delete=True seq_id="101,102,103-110,120,125-"