### PR TITLE
L2 Bulk support added for SLX 17s devices.

### DIFF
--- a/pyswitch/raw/slxos/ver_17s/acl.py
+++ b/pyswitch/raw/slxos/ver_17s/acl.py
@@ -374,6 +374,43 @@ class Acl(NosBaseAcl):
 
         return user_data
 
+    def validate_mac_std_rules(self, acl_name, acl_rules):
+        user_data_list = []
+        for rule in acl_rules:
+            rule['acl_name'] = acl_name
+            params_validator.validate_params_slx_std_add_or_remove_l2_acl_rule(
+                **rule)
+            rule['address_type'] = 'mac'
+            user_data = self._parse_params_for_add_mac_standard(**rule)
+            user_data_list.append(user_data)
+        return user_data_list
+
+    def validate_mac_ext_rules(self, acl_name, acl_rules):
+        user_data_list = []
+        for rule in acl_rules:
+            rule['acl_name'] = acl_name
+            params_validator. \
+                validate_params_slxos_17s_add_or_remove_l2_acl_rule(**rule)
+            rule['address_type'] = 'mac'
+            user_data = self._parse_params_for_add_mac_extended(**rule)
+            user_data_list.append(user_data)
+        return user_data_list
+
+    def process_response_mac_rule_bulk_req(self, rpc_err, acl_rules,
+                                           failed_seq_id):
+        rpc_err = str(rpc_err)
+        if "Error: Access-list entry already exists" in rpc_err:
+
+            configured_count = 0
+            unconfigured_count = 0
+
+            for rule in acl_rules:
+                if rule['seq_id'] < int(failed_seq_id):
+                    configured_count = configured_count + 1
+                else:
+                    unconfigured_count = unconfigured_count + 1
+        raise ValueError(rpc_err)
+
     def add_l2_acl_rule_bulk(self, **kwargs):
         """
         Add ACL rule to an existing L2 ACL.
@@ -396,4 +433,52 @@ class Acl(NosBaseAcl):
                                                    source='host',
                                                    srchost='2222.2222.2222')
         """
-        raise ValueError('add_l2_acl_rule_bulk not supported on slx 17s yet')
+        if 'acl_rules' not in kwargs or not kwargs['acl_rules']:
+            return True
+
+        acl_rules = kwargs['acl_rules']
+
+        # Parse params
+        acl_name = self.mac.parse_acl_name(**kwargs)
+        callback = kwargs.pop('callback', self._callback)
+        acl = self._get_acl_info(acl_name, get_seqs=True)
+        acl_type = acl['type']
+        address_type = acl['protocol']
+
+        if address_type != 'mac':
+            raise ValueError("mac Rule can not be added to non-mac ACL."
+                             "ACL {} is of type {}"
+                             .format(acl_name, address_type))
+
+        # if there are already configured rules. Make sure that they are
+        # not overlapping with new rules to be configured
+        self.set_seq_id_for_bulk_rules(acl['seq_ids'], acl_rules)
+
+        # Parse parameters
+        if acl_type == 'standard':
+            user_data_list = self.validate_mac_std_rules(acl_name, acl_rules)
+        elif acl_type == 'extended':
+            user_data_list = self.validate_mac_ext_rules(acl_name, acl_rules)
+        else:
+            raise ValueError('{} not supported'.format(acl_type))
+
+        # send the rules in a chunk of Acl.MAC_RULE_CHUNK_SIZE
+        chunks = [user_data_list[i:i + Acl.MAC_RULE_CHUNK_SIZE]
+                  for i in
+                  xrange(0, len(user_data_list), Acl.MAC_RULE_CHUNK_SIZE)]
+
+        for chunk in chunks:
+            t = jinja2.Template(acl_template.acl_rule_mac_bulk)
+            config = t.render(address_type=address_type,
+                              acl_type=acl_type,
+                              acl_name=acl_name,
+                              user_data_list=chunk)
+
+            config = ' '.join(config.split())
+            try:
+                callback(config)
+            except Exception as err:
+                self.process_response_mac_rule_bulk_req(err, acl_rules,
+                                                        chunk[0]['seq_id'])
+
+        return True

--- a/pyswitch/raw/slxos/ver_17s/acl_template.py
+++ b/pyswitch/raw/slxos/ver_17s/acl_template.py
@@ -223,3 +223,70 @@ name[text()=\'{{intf}}\']"></nc:filter>
     {% endif %}
 </get-config>
 """
+
+acl_rule_mac_bulk = """
+<config>
+  <mac xmlns="urn:brocade.com:mgmt:brocade-mac-access-list">
+    <access-list>
+      <{{acl_type}}>
+        <name>{{acl_name}}</name>
+        {% if acl_type == "extended" %}
+          <hide-mac-acl-ext>
+        {% else %}
+          <hide-mac-acl-std>
+        {% endif %}
+
+        {% for ud in user_data_list %}
+          <seq>
+            <seq-id>{{ud.seq_id}}</seq-id>
+            <action>{{ud.action}}</action>
+
+            <source>{{ud.source.source}}</source>
+            {% if ud.source.source != "any" %}
+              {% if ud.source.source == "host" %}
+                <srchost>{{ud.source.srchost}}</srchost>
+              {% else %}
+                <src-mac-addr-mask>{{ud.source.mask}}</src-mac-addr-mask>
+              {% endif %}
+            {% endif %}
+
+            {% if acl_type == "extended" %}
+
+              <dst>{{ud.dst.dst}}</dst>
+              {% if ud.dst.dst != "any" %}
+                {% if ud.dst.dst == "host" %}
+                  <dsthost>{{ud.dst.dsthost}}</dsthost>
+                {% else %}
+                  <dst-mac-addr-mask>{{ud.dst.mask}}</dst-mac-addr-mask>
+                {% endif %}
+              {% endif %}
+
+              {% if ud.ethertype is not none %}
+                <ethertype>{{ud.ethertype}}</ethertype>
+              {% endif %}
+
+              {% if ud.vlan is not none %}
+                <vlan>{{ud.vlan}}</vlan>
+              {% endif %}
+
+              {% if ud.pcp is not none %}
+                <pcp>{{ud.pcp}}</pcp>
+              {% endif %}
+
+            {% endif %}
+
+            {% if ud.count is not none %} <count></count> {% endif %}
+            {% if ud.log is not none %}<log></log> {% endif %}
+          </seq>
+        {% endfor %}
+
+        {% if acl_type == "extended" %}
+          </hide-mac-acl-ext>
+        {% else %}
+          </hide-mac-acl-std>
+        {% endif %}
+      </{{acl_type}}>
+    </access-list>
+  </mac>
+</config>
+"""


### PR DESCRIPTION
Actions executed are:

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.24.85.103 acl_name=ext-l2-acl-bulk  acl_rules='[{"action": "deny", "source": "1111.1111.1111", "src_mac_addr_mask": "1111.1111.1111", "dst": "1111.1111.1111", "dst_mac_addr_mask": "1111.1111.1111"}, {"action": "deny", "source": "1111.1111.1112", "src_mac_addr_mask": "1111.1111.1112", "dst": "1111.1111.1112", "dst_mac_addr_mask": "1111.1111.1112"}, {"action": "deny", "source": "1111.1111.1113", "src_mac_addr_mask": "1111.1111.1113", "dst": "1111.1111.1113", "dst_mac_addr_mask": "1111.1111.1113"}]'

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.24.85.103 acl_name=ext-l2-acl-bulk delete=True seq_id="10,20-"

st2 run network_essentials.add_or_remove_l2_acl_rule mgmt_ip=10.24.85.103 acl_name=ext-l2-acl-bulk delete=True seq_id="all"