### PR TITLE
Error message changed similar to SLX/NOS:MLX-290

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -664,13 +664,7 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        try:
-            ifname_Ids = self.get_interface_name_id_mapping()
-            port_id = ifname_Ids[int_type + name]
-        except KeyError:
-            raise ValueError('Interface %s %s is not found on device' %
-                (int_type, name))
-
+        port_id = self.get_snmp_port_id_by_intf_name(int_type, name)
         callback = kwargs.pop('callback', self._callback)
         valid_int_types = self.valid_int_types
         ifAdminStatus_oid = SnmpMib.mib_oid_map['ifAdminStatus']
@@ -734,16 +728,11 @@ class Interface(BaseInterface):
         int_type = kwargs.pop('int_type').lower()
         name = str(kwargs.pop('name'))
 
-        ifname = int_type + name
+        if_type = int_type
         if int_type == 'port-channel':
             int_type = 'port_channel'
-            ifname = 'LAG' + name
-        try:
-            ifname_Ids = self.get_interface_name_id_mapping()
-            if_id = ifname_Ids[ifname]
-        except KeyError:
-            raise ValueError('Interface %s %s is not found on device' %
-                (int_type, name))
+            if_type = 'LAG'
+        if_id = self.get_snmp_port_id_by_intf_name(if_type, name)
         if if_id is None:
             raise ValueError('Invalid if_id')
         oid = SnmpMib.mib_oid_map['ifOperStatus']
@@ -804,12 +793,7 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        try:
-            ifname_Ids = self.get_interface_name_id_mapping()
-            port_id = ifname_Ids[int_type + name]
-        except KeyError:
-            raise ValueError('Interface %s %s is not found on device' %
-                (int_type, name))
+        port_id = self.get_snmp_port_id_by_intf_name(int_type, name)
         callback = kwargs.pop('callback', self._callback)
         valid_int_types = self.valid_int_types
         ifAlias = SnmpMib.mib_oid_map['ifAlias']
@@ -1293,15 +1277,7 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        try:
-            ifname_Ids = self.get_interface_name_id_mapping()
-            port_id = ifname_Ids[int_type + name]
-        except KeyError:
-            raise ValueError('Interface %s %s is not found on device' %
-                (int_type, name))
-        if port_id is None:
-            raise ValueError('pass valid port-id')
-
+        port_id = self.get_snmp_port_id_by_intf_name(int_type, name)
         mtu_oid = SnmpMib.mib_oid_map['snRtIpPortIfMtu'] + '.' + str(port_id)
         mtu_v6_oid = SnmpMib.mib_oid_map['ipv6IfEffectiveMtu'] + '.' + str(port_id)
 
@@ -2688,3 +2664,22 @@ class Interface(BaseInterface):
             NotImplementedError
         """
         raise NotImplementedError("Not supported for MLX platform")
+
+    def get_snmp_port_id_by_intf_name(self, int_type, int_name):
+        """ Get SNMP port-id using interface type and name
+        Args:
+           int_type(str): interface type
+           int_name(str): interface name e.g 0/1, 2/1/1, 1, 2
+        Returns:
+            snmp port-id
+        Raises:
+            ValueError - invalid intf type and name
+        """
+
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            port_id = ifname_Ids[int_type + int_name]
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, int_name))
+        return port_id

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -664,8 +664,13 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        ifname_Ids = self.get_interface_name_id_mapping()
-        port_id = ifname_Ids[int_type + name]
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            port_id = ifname_Ids[int_type + name]
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, name))
+
         callback = kwargs.pop('callback', self._callback)
         valid_int_types = self.valid_int_types
         ifAdminStatus_oid = SnmpMib.mib_oid_map['ifAdminStatus']
@@ -733,8 +738,12 @@ class Interface(BaseInterface):
         if int_type == 'port-channel':
             int_type = 'port_channel'
             ifname = 'LAG' + name
-        ifname_Ids = self.get_interface_name_id_mapping()
-        if_id = ifname_Ids[ifname]
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            if_id = ifname_Ids[ifname]
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, name))
         if if_id is None:
             raise ValueError('Invalid if_id')
         oid = SnmpMib.mib_oid_map['ifOperStatus']
@@ -795,8 +804,12 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        ifname_Ids = self.get_interface_name_id_mapping()
-        port_id = ifname_Ids[int_type + name]
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            port_id = ifname_Ids[int_type + name]
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, name))
         callback = kwargs.pop('callback', self._callback)
         valid_int_types = self.valid_int_types
         ifAlias = SnmpMib.mib_oid_map['ifAlias']
@@ -1209,8 +1222,12 @@ class Interface(BaseInterface):
             raise ValueError('int_type must be one of: %s' %
                              repr(valid_int_types))
 
-        ifname_Ids = self.get_interface_name_id_mapping()
-        lag_name = self.get_lag_id_name_map(str(name))
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            lag_name = self.get_lag_id_name_map(str(name))
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, name))
         if int_type + name in ifname_Ids or lag_name is not None:
             return True
         else:
@@ -1276,9 +1293,12 @@ class Interface(BaseInterface):
             name = self.get_lag_primary_port(name)
             int_type = 'ethernet'
 
-        ifname_Ids = self.get_interface_name_id_mapping()
-        port_id = ifname_Ids[int_type + name]
-
+        try:
+            ifname_Ids = self.get_interface_name_id_mapping()
+            port_id = ifname_Ids[int_type + name]
+        except KeyError:
+            raise ValueError('Interface %s %s is not found on device' %
+                (int_type, name))
         if port_id is None:
             raise ValueError('pass valid port-id')
 


### PR DESCRIPTION
vagrant (intf_error *) PySwitchLib
$  st2 run network_essentials.set_intf_admin_state mgmt_ip=10.20.179.132 intf_type=ethernet intf_name=1/1
..
id: 5a7cebf9c4da5f04e0bb3698
status: failed
parameters: 
  intf_name: 1/1
  intf_type: ethernet
  mgmt_ip: 10.20.179.132
result: 
  exit_code: 1
  result: None
  stderr: "st2.actions.python.SetIntfAdminState: DEBUG    Creating new Client object.\nNo handlers could be found for logger \"st2.st2common.services.access\"\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.user)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.passwd)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.enablepass)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.ostype)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpver)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpport)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.132.snmpv2c)\nst2.actions.python.SetIntfAdminState: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)\nst2.actions.python.SetIntfAdminState: INFO     successfully connected to 10.20.179.132 to enable interface\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 275, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 163, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_intf_admin_state.py\", line 58, in run\n    intf_desc=intf_desc)\n  File \"/opt/stackstorm/packs/network_essentials/actions/set_intf_admin_state.py\", line 78, in _set_intf_admin_state\n    conf = device.interface.admin_state(get=True, name=intf, int_type=intf_type)\n  File \"/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/snmp/mlx/base/interface.py\", line 672, in admin_state\n    (int_type, name))\nValueError: Interface ethernet 1/1 is not found on device\n"
  stdout: ''
vagrant (intf_error) PySwitchLib
$ 
