### PR TITLE
Fix for defect MLX-296

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -119,7 +119,6 @@ class Interface(BaseInterface):
         try:
             cli_arr = []
             for vlan in vlan_id_list:
-                self._callback(cli_arr, handler='cli-set')
                 if desc is None:
                     cli_arr.append('vlan' + " " + str(vlan))
                 else:


### PR DESCRIPTION
Removed a CLI-set callback which was causing delay during VLAN creation.
