### PR TITLE
Mac Move Detection Fix

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -6195,7 +6195,7 @@ class Interface(object):
             output = callback((method_name, {}), handler='get_config')
             util = Util(output.data)
             item = util.find(util.root, './/detect')
-            if item is not None:
+            if item == 'true':
                 return True
             else:
                 return None


### PR DESCRIPTION
Fixing the issue in pyswitch wrapper API where logic works only for system default config resulting in mac-move detection configuration fails after disabling the same. 

vagrant@st2vagrant:/opt/stackstorm/virtualenvs/network_essentials/lib$ st2 run network_essentials.configure_mac_move_detection mgmt_ip="10.24.86.96" username="admin" password="password"
......
id: 5a83404ac4da5f04d600ddb0
status: succeeded
parameters: 
  mgmt_ip: 10.24.86.96
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    conv-arp: true
  stderr: 'st2.actions.python.ConfigureMacMoveDetection: INFO     successfully connected to 10.24.86.96

    st2.actions.python.ConfigureMacMoveDetection: INFO     Configuring Mac Move Detect Enable

    st2.actions.python.ConfigureMacMoveDetection: INFO     Configuring Mac Move threshold 5 on the Switch

    st2.actions.python.ConfigureMacMoveDetection: INFO     closing connection to 10.24.86.96 after configuring mac move detect enable and limit-- all done!

    '
vagrant@st2vagrant:/opt/stackstorm/virtualenvs/network_essentials/lib$ st2 run network_essentials.configure_mac_move_detection mgmt_ip="10.24.86.96" username="admin" password="password"
......
id: 5a8340bec4da5f04d600ddb3
status: succeeded
parameters: 
  mgmt_ip: 10.24.86.96
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    conv-arp: false
  stderr: 'st2.actions.python.ConfigureMacMoveDetection: INFO     successfully connected to 10.24.86.96

    st2.actions.python.ConfigureMacMoveDetection: INFO     Mac Move detect enable already configured

    st2.actions.python.ConfigureMacMoveDetection: INFO     Mac Move threshold 5 already configured

    st2.actions.python.ConfigureMacMoveDetection: INFO     closing connection to 10.24.86.96 after configuring mac move detect enable and limit-- all done!

    '
vagrant@st2vagrant:/opt/stackstorm/virtualenvs/network_essentials/lib$ st2 run network_essentials.unconfigure_mac_move_detection mgmt_ip="10.24.86.96" username="admin" password="password"
......
id: 5a8340e2c4da5f04d600ddb6
status: succeeded
parameters: 
  mgmt_ip: 10.24.86.96
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    conv-arp: true
  stderr: 'st2.actions.python.UnconfigureMacMoveDetection: INFO     successfully connected to 10.24.86.96

    st2.actions.python.UnconfigureMacMoveDetection: INFO     Disabling Mac Move detect

    st2.actions.python.UnconfigureMacMoveDetection: INFO     closing connection to 10.24.86.96 after unconfiguring mac move detect -- all done!

    '
vagrant@st2vagrant:/opt/stackstorm/virtualenvs/network_essentials/lib$ st2 run network_essentials.configure_mac_move_detection mgmt_ip="10.24.86.96" username="admin" password="password"
......
id: 5a834103c4da5f04d600ddb9
status: succeeded
parameters: 
  mgmt_ip: 10.24.86.96
  password: '********'
  username: admin
result: 
  exit_code: 0
  result:
    conv-arp: true
  stderr: 'st2.actions.python.ConfigureMacMoveDetection: INFO     successfully connected to 10.24.86.96

    st2.actions.python.ConfigureMacMoveDetection: INFO     Configuring Mac Move Detect Enable

    st2.actions.python.ConfigureMacMoveDetection: INFO     Configuring Mac Move threshold 5 on the Switch

    st2.actions.python.ConfigureMacMoveDetection: INFO     closing connection to 10.24.86.96 after configuring mac move detect enable and limit-- all done!

    '
vagrant@st2vagrant:/opt/stackstorm/virtualenvs/network_essentials/lib$ 
