### PR TITLE
MLX-293: Obtain device level lock in api daemon to unblock other actions in case of timeout

### DIFF
--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -292,11 +292,7 @@ class SnmpCliDevice(AbstractDevice):
             elif handler == 'snmp-set-multiple':
                 value = self._mgr['snmp'].set_multiple(call)
             elif handler == 'cli-set' or handler == 'cli-get':
-                self._proxied.netmiko_acquire()
-                try:
-                    value = self._proxied.cli_execution(handler, self.host, call)
-                finally:
-                    self._proxied.netmiko_release()
+                value = self._proxied.cli_execution(handler, self.host, call)
         except SNMPError:
             raise
         except Exception:
@@ -333,7 +329,7 @@ class SnmpCliDevice(AbstractDevice):
                 opt['ip'] = self.host
                 opt['username'] = self._auth[0]
                 opt['password'] = self._auth[1]
-                opt['global_delay_factor'] = 0.5
+                opt['global_delay_factor'] = 0.25
                 if self._enablepass:
                     opt['secret'] = self._enablepass
                 self._proxied.create_netmiko_connection(opt)

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -119,7 +119,6 @@ class Interface(BaseInterface):
         try:
             cli_arr = []
             for vlan in vlan_id_list:
-                self._callback(cli_arr, handler='cli-set')
                 if desc is None:
                     cli_arr.append('vlan' + " " + str(vlan))
                 else:

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -41,7 +41,6 @@ class PySwitchLibApiDaemon(object):
         self._pyro_daemon = pyro_daemon
         self._netmiko_lock = threading.Lock()
         self._netmiko_connection = {}
-        self._timer = None
 
     def _hash_auth_string(self, auth_str):
         salt = uuid.uuid4().hex

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -41,6 +41,7 @@ class PySwitchLibApiDaemon(object):
         self._pyro_daemon = pyro_daemon
         self._netmiko_lock = threading.Lock()
         self._netmiko_connection = {}
+        self._timer = None
 
     def _hash_auth_string(self, auth_str):
         salt = uuid.uuid4().hex
@@ -58,7 +59,7 @@ class PySwitchLibApiDaemon(object):
 
     def create_netmiko_connection(self, opt):
         key = opt['ip']
-        conn_list = ['None', 'None']
+        conn_list = ['None', 'None', 'None']
         net_connect_dict = self._netmiko_connection
         auth = (opt['username'], opt['password'])
         if key not in net_connect_dict:
@@ -69,6 +70,7 @@ class PySwitchLibApiDaemon(object):
                     hashed_auth = self._hash_auth_string(auth)
                     conn_list[0] = net_connect
                     conn_list[1] = hashed_auth
+                    conn_list[2] = threading.Lock()
                     net_connect_dict[key] = conn_list
             except ValueError as err:
                 raise
@@ -77,7 +79,8 @@ class PySwitchLibApiDaemon(object):
 
         else:
             existing_hash = net_connect_dict[key][1]
-            conn_obj = self._get_netmiko_connection(key)
+            conn_list = self._get_netmiko_connection(key)
+            conn_obj = conn_list[0]
             if self._check_auth_string(existing_hash, auth):
                 # case 2: check if connection object is alive
                 if conn_obj.is_alive() is True:
@@ -86,7 +89,9 @@ class PySwitchLibApiDaemon(object):
             # and add new connection object for this
             else:
                 #disconnect stale object
+                conn_list[2].acquire()
                 conn_obj.disconnect()
+                conn_list[2].release()
 
             # Existing object is not valid so clear and create new
             # connection
@@ -97,6 +102,7 @@ class PySwitchLibApiDaemon(object):
                     new_hash = self._hash_auth_string(auth)
                     conn_list[0] = net_connect
                     conn_list[1] = new_hash
+                    conn_list[2] = threading.Lock()
                     net_connect_dict[key] = conn_list
             except ValueError as error:
                 raise
@@ -107,7 +113,6 @@ class PySwitchLibApiDaemon(object):
         key = opt['ip']
         try:
             net_connect = ConnectHandler(**opt)
-            net_connect_dict[key] = net_connect
         except (NetMikoTimeoutException, NetMikoAuthenticationException,) as error:
             reason = error.message
             raise ValueError('[Netmiko Exception:] %s' % reason)
@@ -121,23 +126,28 @@ class PySwitchLibApiDaemon(object):
 
     def _get_netmiko_connection(self, key):
         if key in self._netmiko_connection:
-            return self._netmiko_connection[key][0]
+            return self._netmiko_connection[key]
         else:
             return None
 
+
     def cli_execution(self, handler, host, call):
         value = ''
-        conn_obj = self._get_netmiko_connection(host)
-        if not conn_obj:
+        conn_list = self._get_netmiko_connection(host)
+        if not conn_list:
             return value
+        conn_obj = conn_list[0]
+        conn_list[2].acquire()
         try:
             if handler == 'cli-set':
                 conn_obj.enable()
-                value = conn_obj.send_config_set(call)
+                value = conn_obj.send_config_set(config_commands=call, delay_factor=0.25)
             elif handler == 'cli-get':
                 value = conn_obj.send_command(call)
         except Exception:
             raise Exception
+        finally:
+            conn_list[2].release()
 
         return value
 


### PR DESCRIPTION
- Obtained device level lock to simultaneously execute the action
- Moved lock acquire to pyswitch_api_dameon
-Fix performance issue in create vlan