### PR TITLE
Fix for MLX-93

### DIFF
--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -90,7 +90,7 @@ class Interface(BaseInterface):
             config = getattr(template, 'vlan_create').format(vlan_list=str)
             self._callback(config)
         except Exception as error:
-            raise error
+            raise ValueError(error.message)
 
     def overlay_gateway(self, **kwargs):
         """

--- a/pyswitch/raw/slxos/base/interface.py
+++ b/pyswitch/raw/slxos/base/interface.py
@@ -93,9 +93,9 @@ class Interface(BaseInterface):
             self._callback(config)
             return True
 
-        except Exception:
-            # TODO throw back exception
-            return False
+        except Exception as e:
+            reason = e.message
+            raise ValueError(reason)
 
     def overlay_gateway(self, **kwargs):
         """


### PR DESCRIPTION
- In SLXOS raise an exception in pyswitch to handle error case when create vlan fails. The error message is pushed further to NE action which is displayed to user.
- In NOS raise the exception correctly in pyswitch

Logs:

ubuntu@st2vagrant:~$ st2 run network_essentials.create_vlan mgmt_ip=10.24.93.71 username=admin password=password vlan_id=4091
..
id: 5a878762c4da5f0fff31ed64
status: failed
parameters: 
  mgmt_ip: 10.24.93.71
  password: '********'
  username: admin
  vlan_id: '4091'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.93.71.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.93.71 to create interface vlans

    st2.actions.python.CreateVlan: INFO     User provided vlans contains reserved vlans 4091

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: ERROR    VLAN creation failed due to "4091" is out of range.

    '
  stdout: ''


ubuntu@st2vagrant:~$ st2 run network_essentials.create_vlan mgmt_ip=10.24.81.206 username=admin password=password vlan_id=4091
....
id: 5a878777c4da5f0fff31ed67
status: failed
parameters: 
  mgmt_ip: 10.24.81.206
  password: '********'
  username: admin
  vlan_id: '4091'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.206.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.81.206 to create interface vlans

    st2.actions.python.CreateVlan: INFO     User provided vlans contains reserved vlans 4091

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: ERROR    VLAN creation failed due to NSM_CANNOT_CREATE_VLAN | %Error: Vlan cannot be created, as it is not a user vlan.
