### PR TITLE
Pyswitch changes mlx 307

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -2276,7 +2276,7 @@ class Interface(object):
 
         delete = kwargs.pop('delete', False)
         if delete is True:
-            method_name = 'interface_%s_channel_group_mode_delete' % int_type
+            method_name = 'interface_%s_channel_group_delete' % int_type
             arguments = {int_type: name}
             config = (method_name, arguments)
             return callback(config)

--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -2274,16 +2274,20 @@ class Interface(object):
                 'channel_type': channel_type,
                 'mode': mode}
 
+        mode = kwargs.pop('mode', None)
+        print(mode)
         delete = kwargs.pop('delete', False)
         if delete is True:
-            method_name = 'interface_%s_channel_group_delete' % int_type
+            if mode is None:
+                method_name = 'interface_%s_channel_group_delete' % int_type
+            else:
+                method_name = 'interface_%s_channel_group_mode_delete' % int_type
             arguments = {int_type: name}
             config = (method_name, arguments)
             return callback(config)
 
         channel_type = kwargs.pop('channel_type')
         port_int = kwargs.pop('port_int')
-        mode = kwargs.pop('mode')
 
         valid_modes = ['active', 'on', 'passive']
 

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -273,14 +273,14 @@ class Interface(BaseInterface):
             >>> auth = ('admin', 'admin')
             >>> with pyswitch.device.Device(conn=conn, auth=auth) as dev:
             ...     ports = ['2/1', '2/2']
-            ...     output = dev.interface.remove_intf_from_port_channel(ports, 
+            ...     output = dev.interface.remove_intf_from_port_channel(ports,
             ...                         'ethernet', 50, 'static', 'po50')
             ...     assert output == True
         """
         try:
             cli_arr = []
             if desc is None:
-                raise ValueError('Description is NULL for PO %s'%(portchannel_num))
+                raise ValueError('Description is NULL for PO %s' % (portchannel_num))
             if len(desc) < 1 or len(desc) > 64:
                 raise ValueError('Port-channel name should be 1-64 characters')
             if int(portchannel_num) < 1 or int(portchannel_num) > 256:
@@ -290,7 +290,7 @@ class Interface(BaseInterface):
 
             intf_desc = self.get_lag_id_name_map(str(portchannel_num))
             if intf_desc is not None and desc != intf_desc:
-                raise ValueError('Description mismatch for port-channel %s'%(portchannel_num))
+                raise ValueError('Description mismatch for port-channel %s' % (portchannel_num))
 
             lag_member_dict = {}
             lag_member_dict = self.get_port_channel_member_ports(desc)
@@ -306,7 +306,7 @@ class Interface(BaseInterface):
             # disable the interfaces first
             cli_arr.append('disable' + " " + port_list_str)
             if member_cnt == len(ports):
-                # undeploy the port-channel 
+                # undeploy the port-channel
                 cli_arr.append('no deploy')
             # Remove the interfaces from port-channel
             cli_arr.append('no ports' + " " + port_list_str)


### PR DESCRIPTION
Jira Link: https://stackstorm.atlassian.net/browse/MLX-307
Corresponding NE Changes: https://github.com/StackStorm/network_essentials/tree/NE_Changes_MLX-307

(venv) root@st2vagrant:/Ashok/bwc-tests/robotfm_tests/network_essentials_tests# st2 run network_essentials.create_l2_port_channel mgmt_ip="10.24.85.107" intf_type="ethernet" ports="1/1,1/3" port_channel_id="100" protocol="modeon" port_channel_desc="Port_Channel_100"
...
id: 5a8f1f41c4da5f12a8de7f72
status: succeeded
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  port_channel_desc: Port_Channel_100
  port_channel_id: '100'
  ports:
  - 1/1
  - 1/3
  protocol: modeon
result: 
  exit_code: 0
  result:
    port_channel_configs: true
    pre_validation: true
  stderr: 'st2.actions.python.CreatePortChannel: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.passwd)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.24.85.107 to create port channel
    st2.actions.python.CreatePortChannel: INFO     Configuring port channel 100 with type as static on interfaces [u''1/1'', u''1/3''] is done
    st2.actions.python.CreatePortChannel: INFO     intf_type ethernet ports [u''1/1'', u''1/3'']
    st2.actions.python.CreatePortChannel: INFO     closing connection to 10.24.85.107 after configuring port channel -- all done!
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok/bwc-tests/robotfm_tests/
(venv) root@st2vagrant:/Ashok/bwc-tests/robotfm_tests/network_essentials_tests# st2 run network_essentials.remove_intf_from_port_channel mgmt_ip="10.24.85.107" intf_type="ethernet" ports="1/1,1/3" port_channel_id="100" protocol="static" port_channel_desc="Port_Channel_100"
...
id: 5a8f2ce0c4da5f12a8de7f75
status: succeeded
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.24.85.107
  port_channel_desc: Port_Channel_100
  port_channel_id: '100'
  ports:
  - 1/1
  - 1/3
  protocol: static
result: 
  exit_code: 0
  result:
    port_channel_cfgs: true
    pre_validation: true
  stderr: 'st2.actions.python.RemoveIntfPortChannel: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.passwd)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.passwd)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.RemoveIntfPortChannel: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.RemoveIntfPortChannel: INFO     successfully connected to 10.24.85.107 to remove the interface(s) from port channel
    st2.actions.python.RemoveIntfPortChannel: INFO     Removing interface [u''1/1'', u''1/3''] from port channel 100 with description Port_Channel_100 succeeded
    st2.actions.python.RemoveIntfPortChannel: INFO     closing connection to 10.24.85.107 after removing interfaces from port channel -- all done!
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok/bwc-tests/robotfm_tests/network_essentials_tests# 
