### PR TITLE
Authentication and deviceCommerror exception is added MLX-300

### DIFF
--- a/pyswitch/AbstractDevice.py
+++ b/pyswitch/AbstractDevice.py
@@ -40,3 +40,10 @@ class AbstractDevice:
     @abc.abstractmethod
     def close(self):
         pass
+
+
+class DeviceCommError(Exception):
+    """
+    Error with device communication.
+    """
+    pass

--- a/pyswitch/NetConfDevice.py
+++ b/pyswitch/NetConfDevice.py
@@ -15,16 +15,10 @@ import pyswitch.raw.nos.base.interface
 import pyswitch.raw.slxos.base.interface
 import pyswitch.utilities as util
 from pyswitch.AbstractDevice import AbstractDevice
+from pyswitch.AbstractDevice import DeviceCommError
 
 NOS_ATTRS = ['snmp', 'interface', 'bgp', 'lldp', 'system', 'services',
              'fabric_service', 'vcs', 'acl']
-
-
-class DeviceCommError(Exception):
-    """
-    Error with device communication.
-    """
-    pass
 
 
 NOS_VERSIONS = {

--- a/pyswitch/RestDevice.py
+++ b/pyswitch/RestDevice.py
@@ -168,13 +168,6 @@ SLXOS_VERSIONS = {
 }
 
 
-class DeviceCommError(Exception):
-    """
-    Error with device communication.
-    """
-    pass
-
-
 class Reply:
     def __init__(self, xml):
         self.data = xml

--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -24,13 +24,6 @@ from pyswitch.snmp.snmpconnector import SNMPError as SNMPError
 from pyswitch.snmp.SnmpMib import SnmpMib as MIB
 
 
-class DeviceCommError(Exception):
-    """
-    Error with device communication.
-    """
-    pass
-
-
 class Reply:
 
     def __init__(self, xml):

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -112,9 +112,12 @@ class PySwitchLibApiDaemon(object):
         key = opt['ip']
         try:
             net_connect = ConnectHandler(**opt)
-        except (NetMikoTimeoutException, NetMikoAuthenticationException,) as error:
+        except NetMikoTimeoutException as error:
             reason = error.message
-            raise ValueError('[Netmiko Exception:] %s' % reason)
+            raise ValueError('[Netmiko Timeout Exception:] %s' % reason)
+        except NetMikoAuthenticationException as error:
+            reason = error.message
+            raise ValueError('[Netmiko Authentication Exception:] %s' % reason)
         except SSHException as error:
             reason = error.message
             raise ValueError('[SSH Exception:] %s' % reason)


### PR DESCRIPTION
$ st2 run network_essentials.validate_vrrpe_state mgmt_ip=10.24.85.107 intf_type=ethernet intf_name=2/6 vrrpe_group=1 username=admin password=admi
...
id: 5a8f7373c4da5f04bd1c27fc
status: failed
parameters: 
  intf_name: 2/6
  intf_type: ethernet
  mgmt_ip:
  - 10.24.85.107
  password: '********'
  username:
  - admin
  vrrpe_group: '1'
result: 
  exit_code: 0
  result:
    reason: '[Netmiko Authentication Exception:] Authentication failure: unable to connect brocade_netiron 10.24.85.107:22

      Authentication failed.'
    reason_code: 2
  stderr: 'st2.actions.python.validate_vrrpe_state: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: '[Netmiko Authentication Exception:] Authentication failure: unable to connect brocade_netiron 10.24.85.107:22

    Authentication failed.

    '
vagrant (validate_vrrp) network_essentials
$ st2 run network_essentials.validate_vrrpe_state mgmt_ip=10.24.85.107 intf_type=ethernet intf_name=2/6 vrrpe_group=1 username=admin password=admin
.....
id: 5a8f7397c4da5f04bd1c27ff
status: failed
parameters: 
  intf_name: 2/6
  intf_type: ethernet
  mgmt_ip:
  - 10.24.85.107
  password: '********'
  username:
  - admin
  vrrpe_group: '1'
result: 
  exit_code: 0
  result:
    reason: ethernet intf_name 2/6 doesnt exist
    reason_code: 3
  stderr: 'st2.actions.python.validate_vrrpe_state: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: ''
vagrant (validate_vrrp) network_essentials
$ st2 run network_essentials.validate_vrrpe_state mgmt_ip=10.24.85.102 intf_type=ethernet intf_name=2/6 vrrpe_group=1 username=admin password=admin
...
id: 5a8f73aac4da5f04bd1c2802
status: failed
parameters: 
  intf_name: 2/6
  intf_type: ethernet
  mgmt_ip:
  - 10.24.85.102
  password: '********'
  username:
  - admin
  vrrpe_group: '1'
result: 
  exit_code: 0
  result:
    reason: 'Status Code: 401, Error: Invalid Authentication Credentials.'
    reason_code: 2
  stderr: 'st2.actions.python.validate_vrrpe_state: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.user)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.ostype)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.102.snmpv2c)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: ''
vagrant (validate_vrrp) network_essentials
$ st2 run network_essentials.validate_vrrpe_state mgmt_ip=10.24.85.103 intf_type=ethernet intf_name=2/6 vrrpe_group=1 username=admin password=admin
...
id: 5a8f73c2c4da5f04bd1c2805
status: failed
parameters: 
  intf_name: 2/6
  intf_type: ethernet
  mgmt_ip:
  - 10.24.85.103
  password: '********'
  username:
  - admin
  vrrpe_group: '1'
result: 
  exit_code: 0
  result:
    reason: 'Status Code: 401, Error: Invalid Authentication Credentials.'
    reason_code: 2
  stderr: 'st2.actions.python.validate_vrrpe_state: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.user)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.ostype)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.snmpver)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.103.snmpv2c)

    st2.actions.python.validate_vrrpe_state: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    '
  stdout: ''
vagrant (validate_vrrp) network_essentials
$ 
