### PR TITLE
Add platform type information in device context

### DIFF
--- a/pyswitch/AbstractDevice.py
+++ b/pyswitch/AbstractDevice.py
@@ -25,6 +25,10 @@ class AbstractDevice:
         pass
 
     @abc.abstractproperty
+    def platform_type(self):
+        pass
+
+    @abc.abstractproperty
     def firmware_version(self):
         pass
 

--- a/pyswitch/NetConfDevice.py
+++ b/pyswitch/NetConfDevice.py
@@ -118,6 +118,7 @@ class NetConfDevice(AbstractDevice):
 
         self.reconnect()
         self._fetch_firmware_version()
+        self.platform_type_val = None
 
         self.fullver = self.firmware_version
 
@@ -190,6 +191,10 @@ class NetConfDevice(AbstractDevice):
         self._mgr.timeout = 600
 
         return True
+
+    @property
+    def platform_type(self):
+        return self.platform_type_val
 
     def _callback_main(self, call, handler='edit_config', target='running',
                        source='startup'):

--- a/pyswitch/RestDevice.py
+++ b/pyswitch/RestDevice.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 import re
 import sys
+import json
 
 import pyswitch.os.base.fabric_service
 import pyswitch.os.base.lldp
@@ -200,6 +201,7 @@ class RestDevice(AbstractDevice):
         self._callback = kwargs.pop('callback', None)
         self.os_type_val = None
         self._rest_proto = None
+        self.platform_type_val = None
 
         if len(self._conn) >= 3:
             self._rest_proto = self._conn[2]
@@ -271,6 +273,20 @@ class RestDevice(AbstractDevice):
             return self._mgr.connected
         else:
             return False
+
+    @property
+    def platform_type(self):
+        """
+          currently this code works for SLX and NOS.
+          In future if new OS gets added then the rest request
+          will vary
+        """
+        if self.platform_type_val is None:
+            response = self._mgr.run_command(command="show chassis \| inc Chassis")
+            output = response[1][0][self.host]['response']['text']
+            dict_output = json.loads(output)
+            self.platform_type_val = dict_output['output'][0].split(":")[1].strip()
+        return self.platform_type_val
 
     @property
     def os_type(self):

--- a/pyswitch/SnmpCliDevice.py
+++ b/pyswitch/SnmpCliDevice.py
@@ -132,7 +132,7 @@ class SnmpCliDevice(AbstractDevice):
 
         # self._os_type = version_list[0][2]
         devicemap = SNMPUtils.SNMP_DEVICE_MAP[sysobj]
-        self.devicetype = devicemap[0]
+        self.platform_type_val = devicemap[0]
         self._os_type = devicemap[1]
         self.fullver = self.firmware_version
         # self.fullver = version_list[0][1]
@@ -214,6 +214,10 @@ class SnmpCliDevice(AbstractDevice):
         """
         oid = SNMPUtils.DEVICE_FIRMWARE_MAP[self.os_type]
         return self._mgr['snmp'].get_os_version(oid)
+
+    @property
+    def platform_type(self):
+        return self.platform_type_val
 
     def _callback_main(self, call, handler='snmp-get', target='running',
                        source='startup'):

--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -58,6 +58,7 @@ class Device(object):
         snmpver = 0
         sysobj = ''
 
+
         if snmpconfig:
             snmpport = snmpconfig['snmpport']
             snmpver = snmpconfig['version']
@@ -79,6 +80,7 @@ class Device(object):
                    if SNMP is not supported then fallback to other connection type
                 """
                 pass
+
 
         if sysobj in SNMPUtils.SNMP_DEVICE_MAP:
             self.connection_type = 'SNMPCLI'
@@ -108,6 +110,10 @@ class Device(object):
     @property
     def suports_rbridge(self):
         return self.device_type.suports_rbridge
+
+    @property
+    def platform_type(self):
+        return self.device_type.platform_type
 
     @property
     def firmware_version(self):

--- a/pyswitch/device.py
+++ b/pyswitch/device.py
@@ -58,7 +58,6 @@ class Device(object):
         snmpver = 0
         sysobj = ''
 
-
         if snmpconfig:
             snmpport = snmpconfig['snmpport']
             snmpver = snmpconfig['version']
@@ -80,7 +79,6 @@ class Device(object):
                    if SNMP is not supported then fallback to other connection type
                 """
                 pass
-
 
         if sysobj in SNMPUtils.SNMP_DEVICE_MAP:
             self.connection_type = 'SNMPCLI'


### PR DESCRIPTION
device has platform_type property added which will provide the chassis name values for slx and vdx devices. For MLX refer  pyswitch/snmp/snmpconnector.py

This has been fixed only for snmpcli and rest devices. For netconf , there is no operational data support to retrieve chassis name value.

```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/netmiko$ time st2 run network_essentials.create_ve mgmt_ip=10.24.81.125 vlan_id=23 ve_id=23 username=admin password=password
.....
id: 5a8fad55bb0f180b935f377e
status: succeeded
parameters: 
  mgmt_ip: 10.24.81.125
  password: '********'
  username: admin
  ve_id: '23'
  vlan_id: '23'
result: 
  exit_code: 0
  result: {}
  stderr: 'st2.actions.python.CreateVe: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.ostype)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpver)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpport)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpv2c)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.CreateVe: INFO     BR-VDX8770-4
    st2.actions.python.CreateVe: INFO     successfully connected to 10.24.81.125 to create Ve
    st2.actions.python.CreateVe: INFO     VE 23 is pre-existing on rbridge_id 51
    st2.actions.python.CreateVe: INFO     VE 23 is pre-existing on rbridge_id 125
    st2.actions.python.CreateVe: INFO     closing connection to 10.24.81.125 after creating Ve -- all done!
    '
  stdout: ''


ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/netmiko$ time st2 run network_essentials.create_ve mgmt_ip=10.24.12.106 vlan_id=23 ve_id=23 
...
id: 5a8facf1bb0f180b935f3775
status: succeeded
parameters: 
  mgmt_ip: 10.24.12.106
  ve_id: '23'
  vlan_id: '23'
result: 
  exit_code: 0
  result: {}
  stderr: 'st2.actions.python.CreateVe: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.passwd)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)
    st2.actions.python.CreateVe: INFO     CER2024C4X
    st2.actions.python.CreateVe: INFO     successfully connected to 10.24.12.106 to create Ve
    st2.actions.python.CreateVe: INFO     VE 23 is pre-existing on rbridge_id None
    st2.actions.python.CreateVe: INFO     Router VE 23 is pre-existing on vlan_id 23
    st2.actions.python.CreateVe: INFO     closing connection to 10.24.12.106 after creating Ve -- all done!
    '
  stdout: ''

real	0m7.233s
user	0m0.496s
sys	0m0.188s
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/netmiko$ time st2 run network_essentials.create_ve mgmt_ip=10.24.86.96 vlan_id=23 ve_id=23 
...
id: 5a8fad13bb0f180b935f3778
status: succeeded
parameters: 
  mgmt_ip: 10.24.86.96
  ve_id: '23'
  vlan_id: '23'
result: 
  exit_code: 0
  result: {}
  stderr: 'st2.actions.python.CreateVe: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.user)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.passwd)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.ostype)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpver)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpport)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.10.24.86.96.snmpv2c)
    st2.actions.python.CreateVe: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.CreateVe: INFO     BR-SLX9140
    st2.actions.python.CreateVe: INFO     successfully connected to 10.24.86.96 to create Ve
    st2.actions.python.CreateVe: INFO     VE 23 is pre-existing on rbridge_id None
    st2.actions.python.CreateVe: INFO     Router VE 23 is pre-existing on vlan_id 23
    st2.actions.python.CreateVe: INFO     closing connection to 10.24.86.96 after creating Ve -- all done!
    '
  stdout: ''

```