### PR TITLE
Fix for defect mlx-318

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1372,8 +1372,9 @@ class Interface(BaseInterface):
                 raise ValueError('Failed to get vrf details %s' % (reason))
 
             for line in cli_output.split('\n'):
-                if(re.search(', default', line)):
-                    vrf_name = re.split('[\s,]', line)[1]
+                vrf_pattern = re.search(r'VRF (.+), default (.+)', line)
+                if vrf_pattern:
+                    vrf_name = vrf_pattern.group(1)
                     result.append({'vrf_name': vrf_name})
             return result
 
@@ -1656,7 +1657,7 @@ class Interface(BaseInterface):
             if int_type == 've':
                 cli_arr = []
                 cli_arr.append('interface ve ' + name)
-                cli_arr.append('no vrf forwarding ' + in_vrf_name)
+                cli_arr.append('no vrf forwarding ' + '"' + in_vrf_name + '"')
                 cli_res = self._callback(cli_arr, handler='cli-set')
                 error = re.search(r'Error(.+)', cli_res)
                 if error:
@@ -1665,7 +1666,7 @@ class Interface(BaseInterface):
         if int_type == 've':
             cli_arr = []
             cli_arr.append('interface ve ' + name)
-            cli_arr.append('vrf forwarding ' + in_vrf_name)
+            cli_arr.append('vrf forwarding ' + '"' + in_vrf_name + '"')
             cli_res = self._callback(cli_arr, handler='cli-set')
             error = re.search(r'Error(.+)', cli_res)
             if error:


### PR DESCRIPTION
- Address the VRF assignment of VE with spaces during VE creation/deletion 

ubuntu@st2vagrant:~$ st2 run network_essentials.create_ve mgmt_ip='10.24.85.107' username='admin' password='admin' vlan_id=21 ve_id=21 vrf_name="vrf ext1" ipv6_use_link_local_only=True ip_address=21.7.7.7/24
...............
id: 5a904bdfc4da5f0fff31ef4a
status: succeeded
parameters: 
  ip_address:
  - 21.7.7.7/24
  ipv6_use_link_local_only: true
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  ve_id: '21'
  vlan_id: '21'
  vrf_name: vrf ext1
result: 
  exit_code: 0
  result:
    assign_ip: true
    create_ve: true
    pre_validation_ip: true
    pre_validation_vrf: true
    vrf_configs: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.CreateVe: INFO     successfully connected to 10.24.85.107 to create Ve

    st2.actions.python.CreateVe: INFO     Creating VE 21 on rbridge-id None

    st2.actions.python.CreateVe: INFO     Configuring VRF vrf ext1 on Ve 21 on rbridge-id None

    st2.actions.python.CreateVe: INFO     Assigning IP address 21.7.7.7/24 to VE 21 on rbridge-id None

    st2.actions.python.CreateVe: INFO     Configuring IPV6 link local on Ve 21 on rbridge_id None is successfull

    st2.actions.python.CreateVe: INFO     closing connection to 10.24.85.107 after creating Ve -- all done!

    '
  stdout: ''

