### PR TITLE
Fix for mlx-295

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -124,10 +124,20 @@ class Interface(BaseInterface):
                 else:
                     cli_arr.append('vlan' + " " + str(vlan) + " " + 'name' + " " + '"' + desc + '"')
             self._callback(cli_arr, handler='cli-set')
+            output = self._callback(cli_arr, handler='cli-set')
+            prev = None
+            for line in output.split('\n'):
+                temp = line
+                if 'Error' in line:
+                    vlan_error = re.search(r'#vlan (.+)', prev)
+                    if vlan_error:
+                        failed_vlan = vlan_error.group(1)
+                    raise ValueError("Failed to create VLAN " + failed_vlan + " " + str(line))
+                prev = temp
             return True
         except Exception as error:
             reason = error.message
-            raise ValueError('Failed to create VLAN %s' % (reason))
+            raise ValueError(reason)
 
     def create_port_channel(self, ports, int_type, portchannel_num, mode, po_exists, desc=None):
         """create port channel


### PR DESCRIPTION
- Capture the error and print it when the vlan creation fails due to insufficient vlan ids. Also print the first VLAN that is failing.

logs:
ubuntu@st2vagrant:~$ st2 run network_essentials.create_vlan mgmt_ip=10.24.85.107 username=admin password=admin vlan_id=515-517
........
id: 5a965e39c4da5f0fff31f05e
status: failed
parameters: 
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vlan_id: 515-517
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.85.107 to create interface vlans

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: ERROR    Failed to create VLAN 516 Error: insufficient vlan entries for vlan creation

    '
  stdout: ''
