### PR TITLE
Pyswitch changes for MLX-234

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -4512,7 +4512,7 @@ class Interface(object):
         ve_name = kwargs.pop('name')
         rbridge_id = kwargs.pop('rbridge_id', '1')
         callback = kwargs.pop('callback', self._callback)
-        valid_int_types = ['loopback', 've']
+        valid_int_types = self.valid_int_types
         if int_type not in valid_int_types:
             raise ValueError('`int_type` must be one of: %s' %
                              repr(valid_int_types))

--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -1602,8 +1602,7 @@ class Interface(BaseInterface):
 
     def add_int_vrf(self, **kwargs):
         """
-        Add L3 Interface in Vrf. Currently supports VE interface.
-        TBD for other ethernet and loopback interfaces
+        Add L3 Interface in Vrf. Currently supports VE and ethernet interfaces
 
         Args:
             int_type(str): L3 interface type on which the vrf needs to be configured.
@@ -1654,8 +1653,8 @@ class Interface(BaseInterface):
             raise ValueError('`int_type` must be one of: %s' %
                     repr(valid_int_types))
         if get:
-            if int_type == 've':
-                cli_arr = 'show ip interface ve ' + name
+            if int_type == 've' or int_type == 'ethernet':
+                cli_arr = 'show ip interface ' + int_type + ' ' + name
                 cli_res = self._callback(cli_arr, handler='cli-get')
                 error = re.search(r'Error(.+)', cli_res)
                 if error:
@@ -1664,18 +1663,18 @@ class Interface(BaseInterface):
                 vrf_name = result.group(1).strip()
                 return vrf_name
         if not enable:
-            if int_type == 've':
+            if int_type == 've' or int_type == 'ethernet':
                 cli_arr = []
-                cli_arr.append('interface ve ' + name)
+                cli_arr.append('interface ' + int_type + ' ' + name)
                 cli_arr.append('no vrf forwarding ' + '"' + in_vrf_name + '"')
                 cli_res = self._callback(cli_arr, handler='cli-set')
                 error = re.search(r'Error(.+)', cli_res)
                 if error:
                     raise ValueError("%s" % error.group(0))
                 return True
-        if int_type == 've':
+        if int_type == 've' or int_type == 'ethernet':
             cli_arr = []
-            cli_arr.append('interface ve ' + name)
+            cli_arr.append('interface ' + int_type + ' ' + name)
             cli_arr.append('vrf forwarding ' + '"' + in_vrf_name + '"')
             cli_res = self._callback(cli_arr, handler='cli-set')
             error = re.search(r'Error(.+)', cli_res)


### PR DESCRIPTION
Pyswitch Code changes to support Configuring/Removing of IPv4 and IPv6 addresses on Physical and LAG interfaces.

root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# st2 run network_essentials.configure_ip_on_phy_lag_interface mgmt_ip="10.24.85.107" username="admin" password="admin" intf_type="port_channel" intf_name="200" ip_address="1.1.1.1/24" vrf_name="red"
....
id: 5a9651d1c4da5f12a8de80cd
status: succeeded
parameters: 
  intf_name: '200'
  intf_type: port_channel
  ip_address:
  - 1.1.1.1/24
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vrf_name: red
result: 
  exit_code: 0
  result:
    add_int_vrf: true
    cfg_ip_addr: true
    ipv6_use_link_local_only: false
    pre_check: true
    reason_code: 0
  stderr: 'st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.ConfigureIPOnPhyLAGInterface: INFO     successfully connected to 10.24.85.107 to configure IP address on Physical or LAG interface
    st2.actions.python.ConfigureIPOnPhyLAGInterface: INFO     Configuring IP address in ethernet 200 on 10.24.85.107 succeeded
    st2.actions.python.ConfigureIPOnPhyLAGInterface: INFO     closing connection to 10.24.85.107 after configuring IP address -- all done!
    '
  stdout: ''
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# st2 run network_essentials.remove_ip_on_phy_lag_interface mgmt_ip="10.24.85.107" username="admin" password="admin" intf_type="port_channel" intf_name="200" ip_address="1.1.1.1/24" vrf_name="red"
...
id: 5a9651fdc4da5f12a8de80d0
status: succeeded
parameters: 
  intf_name: '200'
  intf_type: port_channel
  ip_address:
  - 1.1.1.1/24
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vrf_name: red
result: 
  exit_code: 0
  result:
    cfg_ip_addr: true
    ipv6_use_link_local_only: false
    pre_check: true
    reason_code: 0
  stderr: 'st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     successfully connected to 10.24.85.107 to remove IP address from Physical or LAG interface
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     Removing IP address from ethernet 200 on 10.24.85.107 succeeded
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     closing connection to 10.24.85.107 after removing IP address -- all done!
    '
  stdout: ''
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# st2 run network_essentials.remove_ip_on_phy_lag_interface mgmt_ip="10.24.85.107" username="admin" password="admin" intf_type="port_channel" intf_name="200" ip_address="2:2::1/48" vrf_name="red"
...
id: 5a96be7ac4da5f12a8de80d3
status: succeeded
parameters: 
  intf_name: '200'
  intf_type: port_channel
  ip_address:
  - 2:2::1/48
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vrf_name: red
result: 
  exit_code: 0
  result:
    cfg_ip_addr: true
    ipv6_use_link_local_only: false
    pre_check: true
    reason_code: 0
  stderr: 'st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.RemoveIPOnPhyLAGInterface: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     successfully connected to 10.24.85.107 to remove IP address from Physical or LAG interface
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     Removing IP address from ethernet 200 on 10.24.85.107 succeeded
    st2.actions.python.RemoveIPOnPhyLAGInterface: INFO     closing connection to 10.24.85.107 after removing IP address -- all done!
    '
  stdout: ''
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
root@st2vagrant:/Ashok/pyswitchlib/pyswitch# 
