### PR TITLE
remove redundant call to switch

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -123,7 +123,6 @@ class Interface(BaseInterface):
                     cli_arr.append('vlan' + " " + str(vlan))
                 else:
                     cli_arr.append('vlan' + " " + str(vlan) + " " + 'name' + " " + '"' + desc + '"')
-            self._callback(cli_arr, handler='cli-set')
             output = self._callback(cli_arr, handler='cli-set')
             prev = None
             for line in output.split('\n'):


### PR DESCRIPTION
Optimize vlan by removing redundant call to switch.

```
ubuntu@bwcvagrant:/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages$ time st2 run network_essentials.create_vlan mgmt_ip=10.24.85.107 username=admin password=admin vlan_id=2-501
..................................
id: 5a988f66bb0f180b935f37c9
status: succeeded
parameters: 
  mgmt_ip: 10.24.85.107
  password: '********'
  username: admin
  vlan_id: 2-501
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.85.107 to create interface vlans
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: INFO     Closing connection to 10.24.85.107 after creating vlan -- all done!
    '
  stdout: ''

real	1m10.623s
user	0m0.740s
sys	0m0.144s
```