### PR TITLE
Mlx 339

### DIFF
--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -38,9 +38,17 @@ class PySwitchLibApiDaemon(object):
         self._module_name = module_name
         self._module_obj = module_obj
         self._api_lock = threading.Lock()
+        self._api_timer = None
+        self._api_timer_expiration = 5
         self._pyro_daemon = pyro_daemon
         self._netmiko_lock = threading.Lock()
         self._netmiko_connection = {}
+
+    def _api_timer_expiration_handler(self):
+        try:
+            self._api_lock.release()
+        except:
+            pass
 
     def _hash_auth_string(self, auth_str):
         salt = uuid.uuid4().hex
@@ -188,6 +196,8 @@ class PySwitchLibApiDaemon(object):
         """
 
         self._api_lock.acquire()
+        self._apt_timer = threading.Timer(self._api_timer_expiration, self._api_timer_expiration_handler)
+        self._apt_timer.start()
 
     def api_release(self):
         """
@@ -195,6 +205,8 @@ class PySwitchLibApiDaemon(object):
         """
 
         self._api_lock.release()
+        self._apt_timer.cancel()
+        
 
     def _api_validation(self, choices_kwargs_map=None, leaf_os_support_map=None, **kwargs):
         """

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -195,18 +195,27 @@ class PySwitchLibApiDaemon(object):
         This is an auto-generated method for the PySwitchLib.
         """
 
-        self._api_lock.acquire()
-        self._apt_timer = threading.Timer(self._api_timer_expiration, self._api_timer_expiration_handler)
-        self._apt_timer.start()
+        self._api_acquire_lock_with_timer()
 
     def api_release(self):
         """
         This is an auto-generated method for the PySwitchLib.
         """
 
-        self._api_lock.release()
-        self._apt_timer.cancel()
-        
+        self._api_release_lock_with_timer()
+       
+    def _api_acquire_lock_with_timer(self):
+        self._api_lock.acquire()
+
+        self._apt_timer = threading.Timer(self._api_timer_expiration, self._api_timer_expiration_handler)
+        self._apt_timer.start()
+
+    def _api_release_lock_with_timer(self):
+        if self._apt_timer.is_alive():
+            self._apt_timer.cancel()
+
+        if self._api_lock.locked():
+            self._api_lock.release()
 
     def _api_validation(self, choices_kwargs_map=None, leaf_os_support_map=None, **kwargs):
         """

--- a/pyswitchlib/pyswitchlib_api_daemon.py
+++ b/pyswitchlib/pyswitchlib_api_daemon.py
@@ -39,7 +39,7 @@ class PySwitchLibApiDaemon(object):
         self._module_obj = module_obj
         self._api_lock = threading.Lock()
         self._api_timer = None
-        self._api_timer_expiration = 5
+        self._api_timer_expiration = 10
         self._pyro_daemon = pyro_daemon
         self._netmiko_lock = threading.Lock()
         self._netmiko_connection = {}


### PR DESCRIPTION
Will implement a timer on the daemon side to release the lock automatically. Setting the timer for 10 seconds should be sufficient or could be less.

When a pyswitchlib API is invoked on the asset, this results in a remote call to the API daemon. Typically, the client/asset remotely takes the lock, sets it os version, remotely issued the API, and releases the lock. The daemon just translates the pyswitchlib API into a proper REST request which will take very little time (less than a second) once bindings are loaded in the daemon.

The REST requests is issued on client/asset side which will incur the time it takes the switch to handle the REST request/response.