### PR TITLE
MLX-337 VLAN delete optimizations

### DIFF
--- a/pyswitch/os/base/interface.py
+++ b/pyswitch/os/base/interface.py
@@ -155,8 +155,9 @@ class Interface(object):
             self._callback(config)
             return True
 
-        except Exception:
-            return False
+        except Exception as e:
+            reason = e.message
+            raise ValueError(reason)
 
     def enable_switchport(self, inter_type, inter):
         """

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -92,6 +92,33 @@ class Interface(BaseInterface):
         except Exception as error:
             raise ValueError(error.message)
 
+    def del_vlan_int(self, vlan_id_list):
+        """
+        Delete VLAN Interfaces.
+
+        Args:
+            vlan_id_list: List of VLAN interfaces being deleted. Value of 2-4096.
+
+        Returns:
+            True if command completes successfully or False if not.
+
+        Raises:
+            ValueError
+        """
+        try:
+            data_list = []
+            for vlan_id in vlan_id_list:
+                data_list.append(getattr(template, 'vlan_delete').format(vlan_id=vlan_id))
+            str = "".join(data_list)
+
+            config = getattr(template, 'vlan_bulk_delete').format(vlan_list=str)
+            self._callback(config)
+            return True
+
+        except Exception as e:
+            reason = e.message
+            raise ValueError(reason)
+
     def overlay_gateway(self, **kwargs):
         """
 

--- a/pyswitch/raw/nos/base/template.py
+++ b/pyswitch/raw/nos/base/template.py
@@ -34,6 +34,22 @@ vlan_create = """
 </config>
 """
 
+vlan_delete = """
+            <vlan operation="remove">
+               <name>{vlan_id}</name>
+            </vlan>
+"""
+
+vlan_bulk_delete = """
+<config>
+    <interface-vlan xmlns="urn:brocade.com:mgmt:brocade-interface">
+        <interface>
+            {vlan_list}
+        </interface>
+    </interface-vlan>
+</config>
+"""
+
 rbridge_id_interface_loopback_get = """
   /rbridge-id/interface/loopback
 """

--- a/pyswitch/raw/slxos/base/interface.py
+++ b/pyswitch/raw/slxos/base/interface.py
@@ -97,6 +97,33 @@ class Interface(BaseInterface):
             reason = e.message
             raise ValueError(reason)
 
+    def del_vlan_int(self, vlan_id_list):
+        """
+        Delete VLAN Interfaces.
+
+        Args:
+            vlan_id_list: List of VLAN interfaces being deleted. Value of 2-4096.
+
+        Returns:
+            True if command completes successfully or False if not.
+
+        Raises:
+            ValueError
+        """
+        try:
+            data_list = []
+            for vlan_id in vlan_id_list:
+                data_list.append(getattr(template, 'vlan_delete').format(vlan_id=vlan_id))
+            str = "".join(data_list)
+
+            config = getattr(template, 'vlan_bulk_delete').format(vlan_list=str)
+            self._callback(config)
+            return True
+
+        except Exception as e:
+            reason = e.message
+            raise ValueError(reason)
+
     def overlay_gateway(self, **kwargs):
         """
 

--- a/pyswitch/raw/slxos/base/template.py
+++ b/pyswitch/raw/slxos/base/template.py
@@ -17,6 +17,12 @@ vlan_id = """
             </vlan>
 """
 
+vlan_delete = """
+            <vlan operation="remove">
+               <name>{vlan_id}</name>
+            </vlan>
+"""
+
 vlan_id_desc = """
             <vlan>
                <name>{vlan_id}</name>
@@ -25,6 +31,14 @@ vlan_id_desc = """
 """
 
 vlan_create = """
+<config>
+    <interface-vlan xmlns="urn:brocade.com:mgmt:brocade-interface">
+            {vlan_list}
+    </interface-vlan>
+</config>
+"""
+
+vlan_bulk_delete = """
 <config>
     <interface-vlan xmlns="urn:brocade.com:mgmt:brocade-interface">
             {vlan_list}

--- a/pyswitch/snmp/base/interface.py
+++ b/pyswitch/snmp/base/interface.py
@@ -79,12 +79,12 @@ class Interface(object):
         """
         pass
 
-    def del_vlan_int(self, vlan_id):
+    def del_vlan_int(self, vlan_id_list):
         """
         Delete VLAN Interface.
 
         Args:
-            vlan_id (int): ID for the VLAN interface being deleted. Value of 2-4096.
+            vlan_id_list: List of VLAN interfaces being deleted. Value of 1-4090.
 
         Returns:
             True if command completes successfully or False if not.
@@ -101,20 +101,20 @@ class Interface(object):
             ...     output = dev.interface.add_vlan_int(vlan_list, 'vlan_300')
             ...     output = dev.interface.get_vlan_int(300)
             ...     assert output == True
-            ...     ret = dev.interface.del_vlan_int(300)
+            ...     ret = dev.interface.del_vlan_int(vlan_list)
             ...     assert ret == True
         """
         try:
-            if vlan_id < 1 and vlan_id > 4090:
-                raise InvalidVlanId("VLAN id must be between 1-4090")
-            row_status = SnmpMib.mib_oid_map['dot1qVlanStaticRowStatus']
-            oid = row_status + "." + str(vlan_id)
-            config = (oid, 6)
-            ret_value = self._callback(config, handler='snmp-set')
-            if ret_value:
-                return True
-            else:
-                return False
+            for vlan_id in vlan_id_list:
+                if vlan_id < 1 and vlan_id > 4090:
+                    raise InvalidVlanId("VLAN id must be between 1-4090")
+                row_status = SnmpMib.mib_oid_map['dot1qVlanStaticRowStatus']
+                oid = row_status + "." + str(vlan_id)
+                config = (oid, 6)
+                ret_value = self._callback(config, handler='snmp-set')
+                if not ret_value:
+                    return False
+            return True
 
         except Exception as error:
             reason = error.message


### PR DESCRIPTION
- Call to NetConf instead of Rest API to reduce time taken to delete the VLAN's.

Logs:
===
ubuntu@st2vagrant:~$ st2 run network_essentials.delete_vlan mgmt_ip=10.24.81.183 username=admin password=password vlan_id=2000-2500
...............................
id: 5a9e0d35c4da5f0fff31f2a1
status: succeeded
parameters: 
  mgmt_ip: 10.24.81.183
  password: '********'
  username: admin
  vlan_id: 2000-2500
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.24.81.183 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 2000-2500

    st2.actions.python.DeleteVlan: INFO     Closing connection to 10.24.81.183 after Deleting vlans -- all done!

    '
  stdout: ''

