### PR TITLE
MLX-322

### DIFF
--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -341,7 +341,7 @@ def validate_params_slx_add_or_remove_l2_acl_rule(**parameters):
     accepted_params = ['dsthost', 'vlan_tag_format', 'acl_name', 'srchost',
                        'vlan', 'dst_mac_addr_mask', 'arp_guard', 'copy_sflow',
                        'mirror', 'drop_precedence_force', 'count',
-                       'drop_precedence', 'log', 'seq_id', 'dst', 'source',
+                       'log', 'seq_id', 'dst', 'source',
                        'src_mac_addr_mask', 'ethertype', 'action', 'pcp',
                        'device']
     st2_specific_params = []


### PR DESCRIPTION
drop_precedence parameter is not supported on SLX router platform.
Erroring out if parameter is passed to pyswitch.