### PR TITLE
Add util function to validate po id range for all platforms

### DIFF
--- a/pyswitch/snmp/mlx/base/interface.py
+++ b/pyswitch/snmp/mlx/base/interface.py
@@ -173,8 +173,6 @@ class Interface(BaseInterface):
                 raise ValueError('Port channel description is NULL for PO %d', portchannel_num)
             if len(desc) < 1 or len(desc) > 64:
                 raise ValueError('Port-channel name should be 1-64 characters')
-            if int(portchannel_num) < 1 or int(portchannel_num) > 256:
-                raise ValueError('Port-channel id should be between 1 and 256')
             if int_type != 'ethernet':
                 raise ValueError('Not a valid interface type (%s) for MLX' % (int_type))
             # Check if a port-channel exists with same id TBD in action
@@ -524,6 +522,8 @@ class Interface(BaseInterface):
             if 'keep-alive' in line:
                 continue
             po_name = re.search(r'LAG \"(.+)\" ID (.+) \((.+) Deployed\)', line)
+            if po_name is None:
+                continue
             lag_name = po_name.group(1)
             lag_id = po_name.group(2)
             type = po_name.group(3)

--- a/pyswitch/utilities.py
+++ b/pyswitch/utilities.py
@@ -605,3 +605,57 @@ def validate_mac_address(mac):
         return True
     else:
         raise ValueError("Invalid MAC {}".format(mac))
+
+
+def validate_port_channel_id(plat_type, po_id):
+    """
+    This will check if the user entered port-channel id is
+    within the supported range of each platform
+
+    Args:
+        plat_type: Like MLX4, CES2048F, BR-VDX6740, etc
+        po_id: port channel id
+
+    Returns:
+        True/False, reason for failure
+
+    """
+    min_lag = 0
+    max_lag = 0
+    if plat_type == 'MLX4' or plat_type == 'MLX8' or \
+       plat_type == 'MLX16' or plat_type == 'MLX32' or \
+       plat_type == 'MLXXMR4' or plat_type == 'MLXXMR8' or \
+       plat_type == 'MLXXMR16' or plat_type == 'MLXXMR32':
+        min_lag = 1
+        max_lag = 256
+    elif plat_type == 'CES2024F' or plat_type == 'CES2024C' or \
+            plat_type == 'CES2048F' or plat_type == 'CES2048C' or \
+            plat_type == 'CES2048FX' or plat_type == 'CES2048CX' or \
+            plat_type == 'CES2024F4X' or plat_type == 'CES2024C4X' or \
+            plat_type == 'CER2024F' or plat_type == 'CER2024C' or \
+            plat_type == 'CER2048F' or plat_type == 'CER2048C' or \
+            plat_type == 'CER2048FX' or plat_type == 'CER2048CX' or \
+            plat_type == 'CER2024F4X' or plat_type == 'CER2024C4X':
+        min_lag = 1
+        max_lag = 64
+    elif plat_type == 'BR-VDX6740' or plat_type == 'VDX6740T-1G' or \
+            plat_type == 'BR-VDX8770-4' or plat_type == 'BR-VDX8770-8' or \
+            plat_type == 'BR-VDX6940-144S':
+        min_lag = 1
+        max_lag = 6144
+    elif plat_type == 'BR-SLX9240' or plat_type == 'BR-SLX9140':
+        min_lag = 1
+        max_lag = 1024
+    elif plat_type == 'BR-SLX9540':
+        min_lag = 1
+        max_lag = 64
+    elif plat_type == 'BR-SLX9850-8':
+        min_lag = 1
+        max_lag = 512
+    else:
+        return False, "Not a valid/supported platform type"
+    if int(po_id) < min_lag or int(po_id) > max_lag:
+        reason = "Invalid Port-channel id should be between " + str(min_lag) +\
+            " and " + str(max_lag)
+        return False, reason
+    return True, "Success"


### PR DESCRIPTION
- Add util function to validate portchannel id range for all platforms (SLX, VDX, NI)

ubuntu@st2vagrant:~$ st2 run network_essentials.delete_l2_port_channel mgmt_ip='10.24.12.106' username='admin' password='password' port_channel_id=65
..
id: 5aa07138c4da5f0fff31f3f1
status: failed
parameters: 
  mgmt_ip: 10.24.12.106
  password: '********'
  port_channel_id: 65
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)

    st2.actions.python.DeletePortChannel: INFO     successfully connected to 10.24.12.106 to delete l2 port channel

    st2.actions.python.DeletePortChannel: ERROR    Invalid Port-channel id should be between 1 and 64

    '
  stdout: ''


ubuntu@st2vagrant:~$ st2 run network_essentials.create_l2_port_channel mgmt_ip='10.20.179.147' username='admin' password='password' intf_type='ethernet' ports='4/14,4/15' mode='standard' protocol='active' port_channel_desc='po30' port_channel_id=513
....
id: 5aa069adc4da5f0fff31f3af
status: failed
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.20.179.147
  mode: standard
  password: '********'
  port_channel_desc: po30
  port_channel_id: '513'
  ports:
  - 4/14
  - 4/15
  protocol: active
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.20.179.147 to create port channel

    st2.actions.python.CreatePortChannel: ERROR    Invalid Port-channel id should be between 1 and 512

    '
  stdout: 
  
  ubuntu@st2vagrant:~$ st2 run network_essentials.create_l2_port_channel mgmt_ip='10.24.81.183' username='admin' password='password' intf_type='ethernet' ports='0/5,0/6' mode='standard' protocol='active' port_channel_desc='po30' port_channel_id=1025
....
id: 5aa06f89c4da5f0fff31f3e2
status: failed
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.24.81.183
  mode: standard
  password: '********'
  port_channel_desc: po30
  port_channel_id: '1025'
  ports:
  - 0/5
  - 0/6
  protocol: active
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.81.183.snmpv2c)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)

    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.24.81.183 to create port channel

    st2.actions.python.CreatePortChannel: ERROR    Invalid Port-channel id should be between 1 and 1024

    '
  stdout: 
  
  ubuntu@st2vagrant:~$ st2 run network_essentials.validate_L2_port_channel_state mgmt_ip=10.24.85.107 username='admin' password='admin' port_channel_id=1025
....
id: 5aa0737ac4da5f0fff31f418
status: failed
parameters: 
  mgmt_ip: 10.24.85.107
  password: '********'
  port_channel_id: 1025
  username: admin
result: 
  exit_code: 0
  result:
    reason: Invalid Port-channel id should be between 1 and 256
    reason_code: 1
  stderr: 'st2.actions.python.ABCMeta: AUDIT    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.user)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.ostype)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpver)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpport)

    st2.actions.python.ABCMeta: AUDIT    Retrieving value from the datastore (name=switch.10.24.85.107.snmpv2c)

    st2.actions.python.ValidateL2PortChannelState: INFO     successfully connected to 10.24.85.107 to validate l2 port channel

    st2.actions.python.ValidateL2PortChannelState: ERROR    Invalid Port-channel id should be between 1 and 256

    '
  stdout: ''
