### PR TITLE
MLX-367: modify ping returns based on the validate rules defined

### DIFF
--- a/pyswitch/os/base/utils.py
+++ b/pyswitch/os/base/utils.py
@@ -68,8 +68,8 @@ class Utils(object):
                         numips, vrf, count, size, timeout_value)
                 cli_cmd.append(cli)
             return cli_cmd
-        except ValueError:
-            raise ValueError('Invalid IP: %s', numips)
+        except ValueError as e:
+            raise AttributeError(e.message)
 
     def _execute_cli(self, opt, cli_list):
         """
@@ -179,16 +179,18 @@ class Utils(object):
         if not timeout_value:
             timeout_value = 10
         size = kwargs.pop('size', 56)
-        cli_list = self._create_ping_cmd(targets, vrf, count, timeout_value, size)
 
         opt = {'device_type': 'brocade_vdx'}
         opt['ip'] = self._host
         opt['username'] = self._auth[0]
         opt['password'] = self._auth[1]
-        opt['verbose'] = True
         opt['global_delay_factor'] = 0.5
 
-        cli_output = self._execute_cli(opt, cli_list)
+        try:
+            cli_list = self._create_ping_cmd(targets, vrf, count, timeout_value, size)
+            cli_output = self._execute_cli(opt, cli_list)
+        except Exception:
+            raise
 
         failed_ips_list = []
         success_ips_list = []
@@ -201,6 +203,8 @@ class Utils(object):
             elif ipv6_address.search(key):
                 ip = ipv6_address.search(key).group()
             value_list = value.splitlines()
+            p_tx = p_rx = 0
+            p_loss = '100'
             for i, line in enumerate(value_list):
                 if line.startswith('--- ' + ip):
 

--- a/pyswitch/snmp/mlx/base/utils.py
+++ b/pyswitch/snmp/mlx/base/utils.py
@@ -72,8 +72,8 @@ class Utils(BaseUtils):
 
                 cli_cmd.append(cli)
             return cli_cmd
-        except ValueError:
-            raise ValueError('Invalid IP: %s', numips)
+        except ValueError as e:
+            raise AttributeError(e.message)
 
     def _execute_cli(self, cli_list):
         """
@@ -85,8 +85,8 @@ class Utils(BaseUtils):
                 cmd = cmd.strip()
                 cli_output[cmd] = self._callback(cmd, handler='cli-get')
         except Exception as error:
-            reason = error.message
-            raise ValueError("ping execution failed due to %s" % reason)
+            reason = "ping execution failed due to  " + error.message
+            raise ValueError(reason)
         return cli_output
 
     def ping(self, **kwargs):
@@ -176,9 +176,11 @@ class Utils(BaseUtils):
         if not timeout_value:
             timeout_value = 50
         size = kwargs.pop('size', 56)
-        cli_list = self._create_ping_cmd(targets, vrf, count, timeout_value, size)
-
-        cli_output = self._execute_cli(cli_list)
+        try:
+            cli_list = self._create_ping_cmd(targets, vrf, count, timeout_value, size)
+            cli_output = self._execute_cli(cli_list)
+        except Exception:
+            raise
 
         final_output = []
         status = True


### PR DESCRIPTION
Modified ping output based on the rules defined in MLX-297. 

```
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.81.125 targets=10.24.12.106,10.24.85.107 vrf=mgmt-vrf count=4 
.........
id: 5aa0e3c7bb0f18254ae85fae
status: succeeded
parameters: 
  count: 4
  mgmt_ip: 10.24.81.125
  targets:
  - 10.24.12.106
  - 10.24.85.107
  vrf: mgmt-vrf
result: 
  exit_code: 0
  result:
    output:
    - ip_address: 10.24.85.107
      packet loss: 0%
      packets received: 4
      packets transmitted: 4
      result: pass
    - ip_address: 10.24.12.106
      packet loss: 0%
      packets received: 4
      packets transmitted: 4
      result: pass
    reason_code: 0
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.81.125 targets=10.24.12.106,10.24.85.10x7 vrf=mgmt-vrf count=4 
...
id: 5aa0e56abb0f18254ae85fb1
status: failed
parameters: 
  count: 4
  mgmt_ip: 10.24.81.125
  targets:
  - 10.24.12.106
  - 10.24.85.10x7
  vrf: mgmt-vrf
result: 
  exit_code: 0
  result:
    reason: u'10.24.85.10x7' does not appear to be an IPv4 or IPv6 address
    reason_code: 1
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$

ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.81.125 targets=10.24.12.106,10.24.85.107 vrf=mgmt-v2rf count=4 
......
id: 5aa0e5c1bb0f18254ae85fb7
status: failed
parameters: 
  count: 4
  mgmt_ip: 10.24.81.125
  targets:
  - 10.24.12.106
  - 10.24.85.107
  vrf: mgmt-v2rf
result: 
  exit_code: 0
  result:
    output:
    - ip_address: 10.24.85.107
      packet loss: 100%
      packets received: 0
      packets transmitted: 0
      result: fail
    - ip_address: 10.24.12.106
      packet loss: 100%
      packets received: 0
      packets transmitted: 0
      result: fail
    reason_code: 0
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.125.snmpv2c)
    '
  stdout: ''
```