### PR TITLE
MLX-347/348/349: PyswitchLib changes to support system timezone set and validation

### DIFF
--- a/pyswitch/os/base/system.py
+++ b/pyswitch/os/base/system.py
@@ -51,3 +51,61 @@ class System(object):
 
     def persist_config_status(self, **kwargs):
         raise ValueError('Persist configuration is not supported on this platform')
+
+    def clock_timezone(self, **kwargs):
+
+        """ Add/Get clock timezone of the device
+        Args:
+            timezone(str): time-zone for the device
+        Returns:
+            Return value of the callback
+        Raises:
+            KeyError: if `host_name` is not passed.
+            ValueError: if `host_name` is invalid.
+        Examples:
+            >>> import pyswitch.device
+            >>> switches = ['10.24.85.107']
+            >>> auth = ('admin', 'admin')
+            >>> for switch in switches:
+            ...     conn = (switch, '22')
+            ...     with pyswitch.device.Device(conn=conn, auth=auth) as dev:
+            ...         output = dev.system.clock_timezone(timezone='us/alaska', rbridge_id='1')
+            ...         output = dev.system.clock_timezone(timezone='us/alaska')
+            ...         output = dev.system.clock_timezone(get=True)
+            ...         output = dev.system.clock_timezone(get=True, rbridge_id='1')
+        """
+        args = dict()
+        rbridge_id = kwargs.pop('rbridge_id', None)
+        if rbridge_id is not None:
+            method_name = 'rbridge_id_clock_timezone_update'
+            get_method_name = 'rbridge_id_clock_timezone_get'
+        else:
+            method_name = 'clock_update'
+            get_method_name = 'clock_get'
+
+        if rbridge_id is not None:
+            args['rbridge_id'] = rbridge_id
+
+        if kwargs.pop('get', False):
+            result = dict()
+            config = (get_method_name, args)
+            output = self._callback(config, handler='get_config')
+            util = Util(output.data)
+            time_zone = util.find(util.root, './/timezone')
+            result['zone'] = time_zone
+            return result
+
+        args['timezone'] = None
+        timezone_arr = ['Africa/Dar_es_Salaam',
+                        'America/Port-au-Prince',
+                        'Antarctica/DumontDUrville',
+                        'Antarctica/McMurdo',
+                        'Etc/GMT']
+        timezone = kwargs.pop('time_zone')
+        for each_item in timezone_arr:
+            if timezone.lower() == each_item.lower():
+                args['timezone'] = each_item
+        if args['timezone'] is None:
+            args['timezone'] = timezone.title()
+        config = (method_name, args)
+        return self._callback(config)


### PR DESCRIPTION
Code changes to support pyswitchlib for system timezone set and validation in MLX/SLX/VDX switches.

(venv) root@st2vagrant:/Ashok_MLX-347/network_essentials# st2 run network_essentials.set_system_timezone mgmt_ip="10.25.225.222" username=admin password=srasdnbfo time_zone=Antarctica/Dumontdurville rbridge_id=222
....
id: 5aa17540c4da5f12a8de8670
status: succeeded
parameters: 
  mgmt_ip: 10.25.225.222
  password: '********'
  rbridge_id:
  - 222
  time_zone: Antarctica/Dumontdurville
  username: admin
result: 
  exit_code: 0
  result:
    cfg_timezone: true
    pre_check: true
    reason: Configuring timezone Antarctica/Dumontdurville on succeeded
    reason_code: 0
  stderr: 'st2.actions.python.SetSysTimeZone: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.ostype)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpv2c)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.SetSysTimeZone: INFO     successfully connected to 10.25.225.222 to set the time-zone
    st2.actions.python.SetSysTimeZone: INFO     Configuring timezone Antarctica/Dumontdurville on succeeded
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok_MLX-347/network_essentials# st2 run network_essentials.set_system_timezone mgmt_ip="10.25.225.222" username=admin password=srasdnbfo time_zone=Antarctica/Dumontdurville rbridge_id=222
...
id: 5aa17554c4da5f12a8de8673
status: failed
parameters: 
  mgmt_ip: 10.25.225.222
  password: '********'
  rbridge_id:
  - 222
  time_zone: Antarctica/Dumontdurville
  username: admin
result: 
  exit_code: 0
  result:
    reason: Trying to configure the same time_zone Antarctica/Dumontdurville in rbridge 222
    reason_code: 3
  stderr: 'st2.actions.python.SetSysTimeZone: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.ostype)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpv2c)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.SetSysTimeZone: INFO     successfully connected to 10.25.225.222 to set the time-zone
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok_MLX-347/network_essentials# st2 run network_essentials.set_system_timezone mgmt_ip="10.25.225.222" username=admin password=srasdnbfo time_zone=etc/GMT rbridge_id=222
....
id: 5aa17566c4da5f12a8de8676
status: succeeded
parameters: 
  mgmt_ip: 10.25.225.222
  password: '********'
  rbridge_id:
  - 222
  time_zone: etc/GMT
  username: admin
result: 
  exit_code: 0
  result:
    cfg_timezone: true
    pre_check: true
    reason: Configuring timezone etc/GMT on succeeded
    reason_code: 0
  stderr: 'st2.actions.python.SetSysTimeZone: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.ostype)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpv2c)
    st2.actions.python.SetSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.SetSysTimeZone: INFO     successfully connected to 10.25.225.222 to set the time-zone
    st2.actions.python.SetSysTimeZone: INFO     Configuring timezone etc/GMT on succeeded
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok_MLX-347/network_essentials# st2 run network_essentials.validate_system_timezone mgmt_ip="10.25.225.222" username=admin password=srasdnbfo time_zone=Antarctica/Dumontdurville rbridge_id=222
...
id: 5aa17584c4da5f12a8de8679
status: succeeded
parameters: 
  mgmt_ip: 10.25.225.222
  password: '********'
  rbridge_id: '222'
  time_zone: Antarctica/Dumontdurville
  username: admin
result: 
  exit_code: 0
  result:
    reason: Time-zone Antarctica/Dumontdurville is validation failed in rbridge:222
    reason_code: 3
    status: false
    timezone: Etc/GMT
  stderr: 'st2.actions.python.ValidateSysTimeZone: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.restproto)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.restproto)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.user)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.user)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.enablepass)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.enablepass)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.ostype)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpver)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpver)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpport)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpport)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.10.25.225.222.snmpv2c)
    st2.actions.python.ValidateSysTimeZone: DEBUG    Retrieving value from the datastore (name=switch.USER.DEFAULT.snmpv2c)
    st2.actions.python.ValidateSysTimeZone: INFO     successfully connected to 10.25.225.222 to validate the time-zone
    st2.actions.python.ValidateSysTimeZone: INFO     Time-zone Antarctica/Dumontdurville is validation failed in rbridge:222
    st2.actions.python.ValidateSysTimeZone: INFO     closing connection to 10.25.225.222 after Validating system time-zone -- all done!
    '
  stdout: ''
(venv) root@st2vagrant:/Ashok_MLX-347/network_essentials#