### PR TITLE
MLX-360

### DIFF
--- a/pyswitch/raw/slx_nos/acl/ipxacl.py
+++ b/pyswitch/raw/slx_nos/acl/ipxacl.py
@@ -112,6 +112,7 @@ class IpAcl(AclParamParser):
             ret['host_ip'] = v4_str[5:]
             return ret
 
+        v4_str = ' '.join(v4_str.split())
         if '/' in v4_str:
             ip, mask = v4_str.split('/')
 
@@ -122,9 +123,15 @@ class IpAcl(AclParamParser):
                 return ret
 
             if address_type == 'ip':
-                utilities.validate_ip_address(mask, address_type)
-                ret['host_any'] = ip
-                ret['mask'] = mask
+                if mask.isdigit():
+                    if int(mask) < 0 or int(mask) > 32:
+                        raise ValueError("Invalid Prefix: {}. Valid Range "
+                                         "0 to 32".format(mask))
+                    ret['host_any'] = v4_str
+                else:
+                    utilities.validate_ip_address(mask, address_type)
+                    ret['host_any'] = ip
+                    ret['mask'] = mask
                 return ret
 
         raise ValueError("Invalid input param {}".format(input_param))

--- a/pyswitch/raw/slxos/base/acl/acl_template.py
+++ b/pyswitch/raw/slxos/base/acl/acl_template.py
@@ -22,7 +22,7 @@ acl_rule_ip = """
                 {% if source.host_any != "any" %}
                   {% if source.host_any == "host" %}
                     <src-host-ip>{{source.host_ip}}</src-host-ip>
-                  {% elif address_type == "ip" %}
+                  {% elif source.mask is not none %}
                     <src-mask>{{source.mask}}</src-mask>
                   {% endif %}
                 {% endif %}
@@ -57,7 +57,7 @@ acl_rule_ip = """
                   {% if destination.host_any != "any" %}
                     {% if destination.host_any == "host" %}
                       <dst-host-ip>{{destination.host_ip}}</dst-host-ip>
-                    {% elif address_type == "ip" %}
+                    {% elif destination.mask is not none %}
                       <dst-mask>{{destination.mask}}</dst-mask>
                     {% endif %}
                   {% endif %}
@@ -322,7 +322,7 @@ acl_rule_ip_bulk = """
                 {% if ud.source.host_any != "any" %}
                   {% if ud.source.host_any == "host" %}
                     <src-host-ip>{{ud.source.host_ip}}</src-host-ip>
-                  {% elif address_type == "ip" %}
+                  {% elif ud.source.mask is not none %}
                     <src-mask>{{ud.source.mask}}</src-mask>
                   {% endif %}
                 {% endif %}
@@ -357,7 +357,7 @@ acl_rule_ip_bulk = """
                   {% if ud.destination.host_any != "any" %}
                     {% if ud.destination.host_any == "host" %}
                       <dst-host-ip>{{ud.destination.host_ip}}</dst-host-ip>
-                    {% elif address_type == "ip" %}
+                    {% elif ud.destination.mask is not none %}
                       <dst-mask>{{ud.destination.mask}}</dst-mask>
                     {% endif %}
                   {% endif %}


### PR DESCRIPTION
Added support for IPaddress/Prefix format for source and destination parameter of add_ipv4_acl_rule action.

Following combination of parameter for the action is executed to validate the changes and to ensure other test cases are not impacted.

st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.24.66.14 acl_name=xyz action=permit source="5.44.20.0/27 range 3 20" destination="3.33.20.0/24 lt 10" protocol_type=tcp
st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.24.66.14 acl_name=xyz action=permit source="any"
st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.24.66.14 acl_name=xyz action=permit source="host,4.47.20.0"