### PR TITLE
MLX-366

### DIFF
--- a/pyswitch/snmp/base/acl/ipacl.py
+++ b/pyswitch/snmp/base/acl/ipacl.py
@@ -139,23 +139,6 @@ class IpAcl(AclParamParser):
 
         return self._parse_source_destination(parameters['protocol_type'], dst)
 
-    def parse_established(self, **parameters):
-        """
-        parse the established param
-        Args:
-            parameters contains:
-                established(boolean): true/false
-        Returns:
-            Return None or parsed string on success
-        Raise:
-            Raise ValueError exception
-        Examples:
-        """
-        if 'established' not in parameters or not parameters['established']:
-            return None
-
-        return 'established'
-
     def parse_vlan(self, **parameters):
         """
         parse the vlan param
@@ -710,3 +693,36 @@ class IpAcl(AclParamParser):
             return self._parse_icmp_message(icmp_filter[0])
 
         raise ValueError("invalid icmp filter string")
+
+    def parse_tcp_operator(self, **parameters):
+        """
+        parse the icmp_message param
+        Args:
+            parameters contains:
+                tcp_operator(string): Validate comparison operator for TCP port
+                    This parameter works only for tcp protocol.
+                    Allowed values are : established and/or syn
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'tcp_operator' in parameters and parameters['tcp_operator']:
+            tcp_operator = parameters['tcp_operator']
+
+            if 'protocol_type' not in parameters or \
+                    not parameters['protocol_type'] or \
+                    parameters['protocol_type'] != 'tcp':
+
+                raise ValueError("{} tcp operator is supported only for."
+                                 "protocol_type = tcp"
+                                 .format(tcp_operator))
+
+            if tcp_operator in ['established', 'syn', 'established syn',
+                                'syn established']:
+                return tcp_operator
+
+            raise ValueError("Only supported tcp operator are: "
+                             "established and/or syn")
+        return None

--- a/pyswitch/snmp/base/acl/ipv6acl.py
+++ b/pyswitch/snmp/base/acl/ipv6acl.py
@@ -528,9 +528,10 @@ class Ipv6Acl(AclParamParser):
                                  "protocol_type = tcp"
                                  .format(tcp_operator))
 
-            if tcp_operator in ['established', 'syn']:
+            if tcp_operator in ['established', 'syn', 'established syn',
+                                'syn established']:
                 return tcp_operator
 
             raise ValueError("Only supported tcp operator are: "
-                             "established or syn")
+                             "established and/or syn")
         return None

--- a/pyswitch/snmp/base/acl/params_validator.py
+++ b/pyswitch/snmp/base/acl/params_validator.py
@@ -3,12 +3,12 @@ def validate_params_mlx_add_ipv4_rule_acl(**parameters):
 
     required_params = ['source', 'acl_name', 'action']
     accepted_params = ['precedence', 'dscp_marking', 'copy_sflow', 'mirror',
-                       'drop_precedence_force', 'vlan_id', 'established',
+                       'drop_precedence_force', 'vlan_id',
                        'log', 'priority_mapping', 'seq_id', 'destination',
                        'suppress_rpf_drop', 'priority', 'source',
                        'priority_force', 'option', 'acl_name',
                        'drop_precedence', 'fragment', 'dscp', 'protocol_type',
-                       'tos', 'action', 'icmp_filter']
+                       'tos', 'action', 'icmp_filter', 'tcp_operator']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -777,7 +777,8 @@ class Acl(BaseAcl):
         user_data['source_str'] = self.ip.parse_source(**parameters)
         user_data['dst_str'] = self.ip.parse_destination(**parameters)
         user_data['copy_sflow'] = self.ip.parse_copy_sflow(**parameters)
-        user_data['established_str'] = self.ip.parse_established(**parameters)
+        user_data['tcp_operator_str'] = \
+            self.ip.parse_tcp_operator(**parameters)
         user_data['icmp_filter_str'] = \
             self.ip.parse_icmp_filter(**parameters)
         user_data['dscp_mapping_str'] = \

--- a/pyswitch/snmp/mlx/base/acl/acl_template.py
+++ b/pyswitch/snmp/mlx/base/acl/acl_template.py
@@ -91,7 +91,7 @@ add_ip_extended_acl_rule_template = '''
     {% if source_str is not none %} {{ source_str }} {% endif %}
     {% if dst_str is not none %} {{ dst_str }} {% endif %}
     {% if copy_sflow is not none %} {{copy_sflow}} {% endif %}
-    {% if established_str is not none %} {{ established_str }} {% endif %}
+    {% if tcp_operator_str is not none %} {{ tcp_operator_str }} {% endif %}
     {% if icmp_filter_str is not none %} {{ icmp_filter_str }} {% endif %}
     {% if drop_precedence_str is not none %}
         {{ drop_precedence_str }} {% endif %}


### PR DESCRIPTION
IP access-list on MLX supports check for ACK, RST and SYN bit in tcp packet.
These changes handle two defects in the current code:
1. The current code only supported to set ACK and RST bit but not the SYN
bit for ip access-list
2. The current code doesn't not allow to set all the three bits ACK, RST and
SYN bit as part of one rule.

Made changes to fix above issues.

"established" parameter of add_ipv4_rule_acl action is removed as this is
taken care as part of new parameter tcp_operator to have similarity to ipv6
acl rule action. I have checked bwc-tests code to valiate that CI is not broken
because of this change.