### PR TITLE
Fix for MLX-385: Add platform type for Fusion F4 for PO ID range check

### DIFF
--- a/pyswitch/utilities.py
+++ b/pyswitch/utilities.py
@@ -650,7 +650,7 @@ def validate_port_channel_id(plat_type, po_id):
     elif plat_type == 'BR-SLX9540':
         min_lag = 1
         max_lag = 64
-    elif plat_type == 'BR-SLX9850-8':
+    elif plat_type == 'BR-SLX9850-8' or plat_type == 'BR-SLX9850-4':
         min_lag = 1
         max_lag = 512
     else:


### PR DESCRIPTION
Logs:
ubuntu@st2vagrant:~$ st2 run network_essentials.create_l2_port_channel intf_type=ethernet ports=1/6 port_channel_id=513 mgmt_ip=10.17.113.52 username=admin password=password port_channel_desc="po103"
..
id: 5aab08d5c4da5f214afc7330
status: failed
parameters: 
  intf_type: ethernet
  mgmt_ip: 10.17.113.52
  password: '********'
  port_channel_desc: po103
  port_channel_id: '513'
  ports:
  - 1/6
  username: admin
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.CreatePortChannel: DEBUG    Creating new Client object.

    No handlers could be found for logger "st2.st2common.services.access"

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.restproto)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.user)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.enablepass)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.ostype)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.snmpver)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.snmpport)

    st2.actions.python.CreatePortChannel: DEBUG    Retrieving value from the datastore (name=switch.10.17.113.52.snmpv2c)

    st2.actions.python.CreatePortChannel: INFO     successfully connected to 10.17.113.52 to create port channel

    st2.actions.python.CreatePortChannel: ERROR    Invalid Port-channel id should be between 1 and 512

    '
  stdout: ''

