### PR TITLE
MLX-378

### DIFF
--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -273,7 +273,7 @@ def validate_params_slx_add_std_ipv4_rule_acl(**parameters):
 
     required_params = ['source', 'acl_name', 'action']
     accepted_params = ['log', 'seq_id', 'source', 'acl_name', 'count',
-                       'action', 'device']
+                       'action', 'device', 'copy_sflow']
     st2_specific_params = []
 
     received_params = [k for k, v in parameters.iteritems() if v]

--- a/pyswitch/raw/slxos/base/acl/acl_template.py
+++ b/pyswitch/raw/slxos/base/acl/acl_template.py
@@ -400,6 +400,9 @@ acl_rule_ip_bulk = """
 
                 {% if ud.count is not none %} <count></count> {% endif %}
                 {% if ud.log is not none %}<log></log> {% endif %}
+                {% if ud.copy_sflow is not none %}
+                  <copy-sflow></copy-sflow>
+                {% endif %}
               </seq>
           {% endfor %}
           {% if address_type == "ip" %}


### PR DESCRIPTION
copy-sflow is supported for ip standard acl. Code added.

Action:
--------
st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.20.179.147 acl_name=xyz acl_rules='[ {"action": "permit", "source": "host 5.58.0.1","copy_sflow":"true"} ]'                                                                                                                                                                                           ......
id: 5ab06a7be3c93b0acd669a21
status: succeeded
parameters:
  acl_name: xyz
  acl_rules:
  - action: permit
    copy_sflow: 'true'
    source: host 5.58.0.1
  mgmt_ip: 10.20.179.147

Verified:
--------
ip access-list standard xyz
 seq 10 permit host 5.58.0.1 copy-sflow