### PR TITLE
MLX-379

### DIFF
--- a/pyswitch/raw/slxos/base/acl/acl.py
+++ b/pyswitch/raw/slxos/base/acl/acl.py
@@ -721,6 +721,7 @@ class Acl(SlxNosAcl):
             rule['acl_name'] = acl_name
             params_validator.validate_params_slx_add_ipv6_rule_acl(**rule)
             rule['address_type'] = 'ipv6'
+            rule['acl_type'] = 'extended'
             user_data = self._parse_params_for_add_extended(**rule)
             user_data_list.append(user_data)
         return user_data_list

--- a/pyswitch/raw/slxos/base/acl/acl_template.py
+++ b/pyswitch/raw/slxos/base/acl/acl_template.py
@@ -396,6 +396,7 @@ acl_rule_ip_bulk = """
                   {% if ud.fin is not none %} <fin></fin> {% endif %}
                   {% if ud.rst is not none %} <rst></rst> {% endif %}
                   {% if ud.sync is not none %} <sync></sync> {% endif %}
+                  {% if ud.mirror is not none %} <mirror></mirror> {% endif %}
                 {% endif %}
 
                 {% if ud.count is not none %} <count></count> {% endif %}


### PR DESCRIPTION
Added mirror keyword in template.

Action:
------
st2 run network_essentials.add_ipv6_rule_acl mgmt_ip=10.20.179.147 acl_name=xyz acl_rules='[ {"action": "permit", "source": "host 5:57::1","destination":"host 6:55::1","protocol_type":"ipv6" ,"mirror":"true"} ]'

Verified:
--------
ipv6 access-list extended xyz
 seq 10 permit ipv6 host 5:57::1 host 6:55::1 mirror