### PR TITLE
MLX-380

### DIFF
--- a/pyswitch/raw/slxos/base/acl/acl_template.py
+++ b/pyswitch/raw/slxos/base/acl/acl_template.py
@@ -385,6 +385,11 @@ acl_rule_ip_bulk = """
                   {% endif %}
 
                   {% if ud.dscp is not none %} <dscp>{{ud.dscp}}</dscp> {% endif %}
+                  {% if ud.drop_precedence_force is not none %}
+                    <drop-precedence-force>
+                      {{ud.drop_precedence_force}}
+                    </drop-precedence-force>
+                  {% endif %}
 
                   {% if ud.vlan_id is not none %}
                     <vlan>{{ud.vlan_id}}</vlan>


### PR DESCRIPTION
Corrected template to carry drop-precedence-force parameter in config payload.

Action:
------
st2 run network_essentials.add_ipv6_rule_acl mgmt_ip=10.20.179.147 acl_name=xyz acl_rules='[{"action": "permit", "source": "host 5:58::1","destination":"host 6:55::1","protocol_type":"ipv6" ,"drop_precedence_force":"2"} ]'

Verified:
--------
do show running-config ipv6 access-list extended xyz
ipv6 access-list extended xyz
 seq 10 permit ipv6 host 5:58::1 host 6:55::1 drop-precedence-force 2