### PR TITLE
MLX-381

### DIFF
--- a/pyswitch/raw/slx_nos/acl/ipxacl.py
+++ b/pyswitch/raw/slx_nos/acl/ipxacl.py
@@ -65,11 +65,11 @@ class IpAcl(AclParamParser):
         elif xport_val == 'bootps':
             return 67  # Bootstrap Protocol (BOOTP) server (67)
         elif xport_val == 'ntp':
-            return 123 # Network Time Protocol (123)
+            return 123  # Network Time Protocol (123)
         elif xport_val == 'rip':
-            return 520 # Routing Information Protocol (router, in.routed, 520)
+            return 520  # Routing Information Protocol (router, in.routed, 520)
         elif xport_val == 'snmp':
-            return 161 # Simple Network Management Protocol (161)
+            return 161  # Simple Network Management Protocol (161)
         elif xport_val == 'tftp':
             return 69  # Trivial File Transfer Protocol (69)
 

--- a/pyswitch/raw/slx_nos/acl/ipxacl.py
+++ b/pyswitch/raw/slx_nos/acl/ipxacl.py
@@ -60,6 +60,20 @@ class IpAcl(AclParamParser):
             return 37  # Time (37)
         elif xport_val == 'www':
             return 80  # World Wide Web (HTTP, 80)
+        elif xport_val == 'bootpc':
+            return 68  # Bootstrap Protocol (BOOTP) clien (68)
+        elif xport_val == 'bootps':
+            return 67  # Bootstrap Protocol (BOOTP) server (67)
+        elif xport_val == 'ntp':
+            return 123 # Network Time Protocol (123)
+        elif xport_val == 'rip':
+            return 520 # Routing Information Protocol (router, in.routed, 520)
+        elif xport_val == 'snmp':
+            return 161 # Simple Network Management Protocol (161)
+        elif xport_val == 'tftp':
+            return 69  # Trivial File Transfer Protocol (69)
+
+        raise ValueError('{} operator not supported')
 
     def _parse_op_str(self, op_str, ret):
         xport = {}


### PR DESCRIPTION
Added supported protocols for slxos.

Action:
-------
st2 run network_essentials.add_ipv6_rule_acl mgmt_ip=10.20.179.147 acl_name=xyz acl_rules='[{"action": "permit", "source": "4:46::/128 eq bootpc","destination":"5:56::/128 lt pim-auto-rp","protocol_type":"udp" } ]'

Verified:
--------
do show running-config ipv6 access-list extended xyz
ipv6 access-list extended xyz
 seq 10 permit udp 4:46::/128 eq bootpc 5:56::/128 lt pim-auto-rp