### PR TITLE
MLX-376

### DIFF
--- a/pyswitch/raw/slxos/base/acl/acl.py
+++ b/pyswitch/raw/slxos/base/acl/acl.py
@@ -633,6 +633,7 @@ class Acl(SlxNosAcl):
             rule['acl_name'] = acl_name
             params_validator.validate_params_slx_add_ipv4_rule_acl(**rule)
             rule['address_type'] = 'ip'
+            rule['acl_type'] = 'extended'
             user_data = self._parse_params_for_add_extended(**rule)
             user_data_list.append(user_data)
         return user_data_list


### PR DESCRIPTION
acl_type is required to parse mirror parameter.

Action:
-------
 st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.20.179.147 acl_name=xyz acl_rules='[ {"action": "permit", "source": "host 5.57.0.1","destination":"host 6.55.0.1","protocol_type":"ip" ,"mirror":"true"} ]'

Verified:
---------
do show running-config ip access-list extended xyz
ip access-list extended xyz
 seq 10 permit ip host 5.57.0.1 host 6.55.0.1 mirror