### PR TITLE
MLX-389

### DIFF
--- a/pyswitch/raw/nos/base/acl/acl_template.py
+++ b/pyswitch/raw/nos/base/acl/acl_template.py
@@ -22,7 +22,7 @@ acl_rule_ip = """
                 {% if source.host_any != "any" %}
                   {% if source.host_any == "host" %}
                     <src-host-ip>{{source.host_ip}}</src-host-ip>
-                  {% elif address_type == "ip" %}
+                  {% elif source.mask is not none %}
                     <src-mask>{{source.mask}}</src-mask>
                   {% endif %}
                 {% endif %}
@@ -57,7 +57,7 @@ acl_rule_ip = """
                   {% if destination.host_any != "any" %}
                     {% if destination.host_any == "host" %}
                       <dst-host-ip>{{destination.host_ip}}</dst-host-ip>
-                    {% elif address_type == "ip" %}
+                    {% elif destination.mask is not none %}
                       <dst-mask>{{destination.mask}}</dst-mask>
                     {% endif %}
                   {% endif %}
@@ -274,6 +274,7 @@ acl_rule_ip_bulk = """
                   {% if ud.source.host_any == "host" %}
                     <src-host-ip>{{ud.source.host_ip}}</src-host-ip>
                   {% elif address_type == "ip" %}
+                  {% elif ud.source.mask is not none %}
                     <src-mask>{{ud.source.mask}}</src-mask>
                   {% endif %}
                 {% endif %}
@@ -308,7 +309,7 @@ acl_rule_ip_bulk = """
                   {% if ud.destination.host_any != "any" %}
                     {% if ud.destination.host_any == "host" %}
                       <dst-host-ip>{{ud.destination.host_ip}}</dst-host-ip>
-                    {% elif address_type == "ip" %}
+                    {% elif ud.destination.mask is not none %}
                       <dst-mask>{{ud.destination.mask}}</dst-mask>
                     {% endif %}
                   {% endif %}


### PR DESCRIPTION
Changed check to see if mask value is provided in parameter.

Action:
------
 st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.20.61.41 acl_name=xyz source=1.1.1.0/24 protocol_type=135 destination=2.2.2.0/24

Verified:
--------
show running-config ip access-list extended xyz
ip access-list extended xyz
 seq 10 permit 135 1.1.1.0 0.0.0.255 2.2.2.0 0.0.0.255