### PR TITLE
CANDY-1125

### DIFF
--- a/pyswitch/raw/nos/base/acl/acl.py
+++ b/pyswitch/raw/nos/base/acl/acl.py
@@ -225,7 +225,7 @@ class Acl(SlxNosAcl):
         user_data['source'] = self.ip.parse_source(**kwargs)
         user_data['destination'] = self.ip.parse_destination(**kwargs)
         user_data['dscp'] = self.ip.parse_dscp(**kwargs)
-        user_data['vlan_id'] = self.ip.parse_vlan_id(**kwargs)
+        user_data['vlan_id'] = self.ip.parse_nos_vlan_id(**kwargs)
 
         # All these params of same type. Parsing them together
         bool_params = ['urg', 'ack', 'push', 'fin', 'rst', 'sync',

--- a/pyswitch/raw/slx_nos/acl/ipxacl.py
+++ b/pyswitch/raw/slx_nos/acl/ipxacl.py
@@ -357,6 +357,29 @@ class IpAcl(AclParamParser):
         raise ValueError("Invalid \'vlan_id\' {} in kwargs"
                          .format(vlan_id))
 
+    def parse_nos_vlan_id(self, **kwargs):
+        """
+        parse the protocol type param.
+        Args:
+            kwargs contains:
+                vlan_id(integer): VLAN interface to which the ACL is bound
+        Returns:
+            Return None or parsed string on success
+        Raise:
+            Raise ValueError exception
+        Examples:
+        """
+        if 'vlan_id' not in kwargs or not kwargs['vlan_id']:
+            return None
+
+        vlan_id = kwargs['vlan_id']
+
+        if vlan_id >= 1 and vlan_id <= 8191:
+            return str(vlan_id)
+
+        raise ValueError("Invalid \'vlan_id\' {} in kwargs"
+                         .format(vlan_id))
+
     def parse_tcp_specific_params(self, user_data, **kwargs):
         """
         parse the protocol type param.


### PR DESCRIPTION
Changed vlan range from 4095 to 8191 for nos devices.

Action:
-------
st2 run network_essentials.add_ipv6_rule_acl mgmt_ip=10.20.61.37 acl_name=new_ipv6_acl1 action=permit protocol_type=tcp source=7:46::/128 destination=6:56::/128 seq_id=103 vlan_id=8190

Verified:
---------
do show running-config ipv6 access-list extended
ipv6 access-list extended new_ipv6_acl1
 seq 103 permit tcp 7:46::/128 6:56::/128 vlan 8190