### PR TITLE
Candy 1120

### DIFF
--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -312,6 +312,9 @@ class Interface(BaseInterface):
         _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
                                       interface['interface'])
 
+        if intf_type.lower() not in ['loopback', 've']:
+            interface['rbridge_id'] = None
+
         if not validate_interface(intf_type.strip(), port.strip(),
                                   interface['rbridge_id'], 'nos'):
             raise ValueError("Invalid interface: {}{} on platform type: nos. "

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -6,6 +6,7 @@ import json
 import template
 from pyswitch.raw.base.interface import Interface as BaseInterface
 from pyswitch.utilities import Util
+from pyswitch.utilities import validate_interface
 
 
 class Interface(BaseInterface):
@@ -310,6 +311,12 @@ class Interface(BaseInterface):
 
         _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
                                       interface['interface'])
+
+        if not validate_interface(intf_type, port,
+                                  interface['rbridge_id'], 'nos'):
+            raise ValueError("Invalid interface: {} on platform type: nos"
+                             .format(intf_type, port))
+
         if intf_type != 've':
             user_data['port'] = port.strip()
             user_data['intf_type'] = intf_type.strip()
@@ -317,6 +324,11 @@ class Interface(BaseInterface):
 
             # configure interface params
             if intf_type == 'loopback':
+
+                if interface['ip']:
+                    if interface['ip'].split('/')[-1] != '32':
+                        raise ValueError("{} is invalid ip address/mask"
+                                         .format(interface['ip']))
 
                 # This is limitation with switch, hence spliting
                 # loopback creation and admin state seperately.
@@ -349,32 +361,32 @@ class Interface(BaseInterface):
         bfd_rx = parameters.get('bfd_rx', None)
         bfd_tx = parameters.get('bfd_tx', None)
 
-        if not mtu or int(mtu) < 1522 and int(mtu) > 9216:
+        if not mtu or int(mtu) < 1522 or int(mtu) > 9216:
             raise ValueError("Invalid mtu: {}. Valid mtu range is 1522-9216"
                              .format(mtu))
 
-        if not ip_mtu or int(ip_mtu) < 1300 and int(ip_mtu) > 9100:
+        if not ip_mtu or int(ip_mtu) < 1300 or int(ip_mtu) > 9100:
             raise ValueError("Invalid ip_mtu: {}. Valid ip_mtu range is "
                              "1300-9100".format(ip_mtu))
 
-        if not ipv6_mtu or int(ipv6_mtu) < 1280 and int(ipv6_mtu) > 9100:
+        if not ipv6_mtu or int(ipv6_mtu) < 1280 or int(ipv6_mtu) > 9100:
             raise ValueError("Invalid ipv6_mtu: {}. Valid ipv6_mtu range is "
                              "1280-9100".format(ipv6_mtu))
 
         if bfd_multiplier:
-            if int(bfd_multiplier) < 3 and int(bfd_multiplier) > 50:
+            if int(bfd_multiplier) < 3 or int(bfd_multiplier) > 50:
                 raise ValueError("Invalid bfd_multiplier: {}. Valid "
                                  "bfd_multiplier range is 3-50"
                                  .format(bfd_multiplier))
 
         if bfd_rx:
-            if int(bfd_rx) < 50 and int(bfd_rx) > 30000:
+            if int(bfd_rx) < 50 or int(bfd_rx) > 30000:
                 raise ValueError("Invalid bfd_rx: {}. Valid "
                                  "bfd_rx range is 50-30000"
                                  .format(bfd_rx))
 
         if bfd_tx:
-            if int(bfd_tx) < 50 and int(bfd_tx) > 30000:
+            if int(bfd_tx) < 50 or int(bfd_tx) > 30000:
                 raise ValueError("Invalid bfd_tx: {}. Valid "
                                  "bfd_tx range is 50-30000"
                                  .format(bfd_tx))

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -306,7 +306,6 @@ class Interface(BaseInterface):
         parameters.pop('interfaces', None)
 
         user_data = {'ip': interface['ip'],
-                     'donor': interface['donor'],
                      'rbridge_id': interface['rbridge_id']}
 
         _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
@@ -328,6 +327,13 @@ class Interface(BaseInterface):
 
                 t = Template(template.interfaces_loopback_noshut_config_set)
             else:
+
+                if interface['donor']:
+                    _, donor_type, donor_name = re.split('([a-zA-Z]_?[a-zA-Z]*)',
+                                                         interface['donor'])
+                    user_data['donor_type'] = donor_type.strip()
+                    user_data['donor_name'] = donor_name.strip()
+
                 t = Template(template.interfaces_config_set)
 
             config = t.render(**user_data)

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -317,7 +317,19 @@ class Interface(BaseInterface):
             user_data.update(parameters)
 
             # configure interface params
-            t = Template(template.interfaces_config_set)
+            if intf_type == 'loopback':
+
+                # This is limitation with switch, hence spliting
+                # loopback creation and admin state seperately.
+                t = Template(template.interfaces_loopback_ip_config_set)
+                config = t.render(**user_data)
+                config = ' '.join(config.split())
+                self._callback(config)
+
+                t = Template(template.interfaces_loopback_noshut_config_set)
+            else:
+                t = Template(template.interfaces_config_set)
+
             config = t.render(**user_data)
             config = ' '.join(config.split())
             self._callback(config)

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -312,10 +312,12 @@ class Interface(BaseInterface):
         _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
                                       interface['interface'])
 
-        if not validate_interface(intf_type, port,
+        if not validate_interface(intf_type.strip(), port.strip(),
                                   interface['rbridge_id'], 'nos'):
-            raise ValueError("Invalid interface: {} on platform type: nos"
-                             .format(intf_type, port))
+            raise ValueError("Invalid interface: {}{} on platform type: nos. "
+                             "rbridge_id MUST be passed ONLY if interface type"
+                             " is loopback. Provided rbridge_id: {}"
+                             .format(intf_type, port, interface['rbridge_id']))
 
         if intf_type != 've':
             user_data['port'] = port.strip()

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -316,8 +316,49 @@ class Interface(BaseInterface):
             user_data['intf_type'] = intf_type.strip()
             user_data.update(parameters)
 
+            # configure interface params
             t = Template(template.interfaces_config_set)
             config = t.render(**user_data)
             config = ' '.join(config.split())
             self._callback(config)
+        return True
+
+    def validate_ipfabric_params(self, parameters):
+        mtu = parameters.get('mtu', None)
+        ip_mtu = parameters.get('ip_mtu', None)
+        ipv6_mtu = parameters.get('ipv6_mtu', None)
+        bfd_multiplier = parameters.get('bfd_multiplier', None)
+        bfd_rx = parameters.get('bfd_rx', None)
+        bfd_tx = parameters.get('bfd_tx', None)
+
+        if not mtu or int(mtu) < 1522 and int(mtu) > 9216:
+            raise ValueError("Invalid mtu: {}. Valid mtu range is 1522-9216"
+                             .format(mtu))
+
+        if not ip_mtu or int(ip_mtu) < 1300 and int(ip_mtu) > 9100:
+            raise ValueError("Invalid ip_mtu: {}. Valid ip_mtu range is "
+                             "1300-9100".format(ip_mtu))
+
+        if not ipv6_mtu or int(ipv6_mtu) < 1280 and int(ipv6_mtu) > 9100:
+            raise ValueError("Invalid ipv6_mtu: {}. Valid ipv6_mtu range is "
+                             "1280-9100".format(ipv6_mtu))
+
+        if bfd_multiplier:
+            if int(bfd_multiplier) < 3 and int(bfd_multiplier) > 50:
+                raise ValueError("Invalid bfd_multiplier: {}. Valid "
+                                 "bfd_multiplier range is 3-50"
+                                 .format(bfd_multiplier))
+
+        if bfd_rx:
+            if int(bfd_rx) < 50 and int(bfd_rx) > 30000:
+                raise ValueError("Invalid bfd_rx: {}. Valid "
+                                 "bfd_rx range is 50-30000"
+                                 .format(bfd_rx))
+
+        if bfd_tx:
+            if int(bfd_tx) < 50 and int(bfd_tx) > 30000:
+                raise ValueError("Invalid bfd_tx: {}. Valid "
+                                 "bfd_tx range is 50-30000"
+                                 .format(bfd_tx))
+
         return True

--- a/pyswitch/raw/nos/base/template.py
+++ b/pyswitch/raw/nos/base/template.py
@@ -282,15 +282,16 @@ interfaces_config_set = """
     <{{intf_type}}>
       <name>{{port}}</name>
 
-     {% if bfd_tx is not none %}
+
+      {% if bfd_tx is not none %}
         <bfd>
-            <interval>
-              <min-tx>{{bfd_tx}}</min-tx>
-              <min-rx>{{bfd_rx}}</min-rx>
-              <multiplier>{{bfd_multiplier}}</multiplier>
-            </interval>
+                <interval>
+                    <min-tx>{{bfd_tx}}</min-tx>
+                    <min-rx>{{bfd_rx}}</min-rx>
+                    <multiplier>{{bfd_multiplier}}</multiplier>
+                </interval>
         </bfd>
-     {% endif %}
+      {% endif %}
 
       <fabric xmlns="urn:brocade.com:mgmt:brocade-fcoe">
           <fabric-isl>
@@ -305,22 +306,60 @@ interfaces_config_set = """
       </fabric>
 
       <mtu>{{mtu}}</mtu>
+      <switchport-basic operation="remove"><basic></basic></switchport-basic>
 
       <ip>
-          <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
-            <address>
-              <address>{{ip}}</address>
-            </address>
-            <mtu>{{ip_mtu}}</mtu>
-            <proxy-arp></proxy-arp>
+        <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
+          <address>
+            <address>{{ip}}</address>
+          </address>
+          <mtu>{{ip_mtu}}</mtu>
+          <proxy-arp></proxy-arp>
           </ip-config>
       </ip>
-
-
-      <switchport-basic operation="remove"><basic></basic></switchport-basic>
       <shutdown operation="remove"></shutdown>
     </{{intf_type}}>
 
   </interface>
+</config>
+"""
+
+interfaces_loopback_ip_config_set = """
+<config>
+  <rbridge-id xmlns="urn:brocade.com:mgmt:brocade-rbridge">
+    <rbridge-id>{{rbridge_id}}</rbridge-id>
+
+    <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+      <loopback xmlns="urn:brocade.com:mgmt:brocade-intf-loopback">
+        <id>{{port}}</id>
+        <ip xmlns="urn:brocade.com:mgmt:brocade-ip-config">
+          <ip-config >
+            <address> <address>{{ip}}</address> </address>
+          </ip-config>
+        </ip>
+
+      </loopback>
+    </interface>
+  </rbridge-id>
+</config>
+"""
+
+interfaces_loopback_noshut_config_set = """
+<config>
+  <rbridge-id xmlns="urn:brocade.com:mgmt:brocade-rbridge">
+    <rbridge-id>{{rbridge_id}}</rbridge-id>
+
+    <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+      <loopback xmlns="urn:brocade.com:mgmt:brocade-intf-loopback">
+
+        <id>{{port}}</id>
+
+        <intf-loopback>
+            <shutdown operation="remove"></shutdown>
+        </intf-loopback>
+
+      </loopback>
+    </interface>
+  </rbridge-id>
 </config>
 """

--- a/pyswitch/raw/nos/base/template.py
+++ b/pyswitch/raw/nos/base/template.py
@@ -310,9 +310,17 @@ interfaces_config_set = """
 
       <ip>
         <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
-          <address>
-            <address>{{ip}}</address>
-          </address>
+          {% if "unnumbered" == ip %}
+            <unnumbered>
+              <ip-donor-interface-type>{{donor_type}}</ip-donor-interface-type>
+              <ip-donor-interface-name>{{donor_name}}</ip-donor-interface-name>
+            </unnumbered>
+          {% else %}
+            <address>
+              <address>{{ip}}</address>
+            </address>
+          {% endif %}
+
           <mtu>{{ip_mtu}}</mtu>
           <proxy-arp></proxy-arp>
           </ip-config>

--- a/pyswitch/raw/nos/base/template.py
+++ b/pyswitch/raw/nos/base/template.py
@@ -266,3 +266,57 @@ acl_rule_ip = """
    </{address_type}-acl>
 </config>
 """
+
+
+interfaces_config_get = """
+<get-config> <source> <running/> </source>
+  <nc:filter type="xpath" select="//{{intf_type}}[{{interface_names}}]"></nc:filter>
+</get-config>
+"""
+
+
+interfaces_config_set = """
+<config>
+  <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+
+    <{{intf_type}}>
+      <name>{{port}}</name>
+      <bfd>
+          <interval>
+            <min-tx>{{bfd_tx}}</min-tx>
+            <min-rx>{{bfd_rx}}</min-rx>
+            <multiplier>{{bfd_multiplier}}</multiplier>
+          </interval>
+      </bfd>
+
+      <fabric xmlns="urn:brocade.com:mgmt:brocade-fcoe">
+          <fabric-isl>
+            <fabric-isl-enable operation="remove"></fabric-isl-enable>
+          </fabric-isl>
+
+          <neighbor-discovery> <disable></disable> </neighbor-discovery>
+
+          <fabric-trunk>
+            <fabric-trunk-enable operation="remove"></fabric-trunk-enable>
+          </fabric-trunk>
+      </fabric>
+
+      <ip>
+          <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
+            <address>
+              <address>{{ip}}</address>
+            </address>
+            <mtu>{{ip_mtu}}</mtu>
+            <proxy-arp></proxy-arp>
+          </ip-config>
+      </ip>
+
+      <mtu>{{mtu}}</mtu>
+      <switchport operation="remove"></switchport>
+
+      <shutdown operation="remove"></shutdown>
+    </{{intf_type}}>
+
+  </interface>
+</config>
+"""

--- a/pyswitch/raw/nos/base/template.py
+++ b/pyswitch/raw/nos/base/template.py
@@ -281,13 +281,16 @@ interfaces_config_set = """
 
     <{{intf_type}}>
       <name>{{port}}</name>
-      <bfd>
-          <interval>
-            <min-tx>{{bfd_tx}}</min-tx>
-            <min-rx>{{bfd_rx}}</min-rx>
-            <multiplier>{{bfd_multiplier}}</multiplier>
-          </interval>
-      </bfd>
+
+     {% if bfd_tx is not none %}
+        <bfd>
+            <interval>
+              <min-tx>{{bfd_tx}}</min-tx>
+              <min-rx>{{bfd_rx}}</min-rx>
+              <multiplier>{{bfd_multiplier}}</multiplier>
+            </interval>
+        </bfd>
+     {% endif %}
 
       <fabric xmlns="urn:brocade.com:mgmt:brocade-fcoe">
           <fabric-isl>
@@ -301,6 +304,8 @@ interfaces_config_set = """
           </fabric-trunk>
       </fabric>
 
+      <mtu>{{mtu}}</mtu>
+
       <ip>
           <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
             <address>
@@ -311,9 +316,8 @@ interfaces_config_set = """
           </ip-config>
       </ip>
 
-      <mtu>{{mtu}}</mtu>
-      <switchport operation="remove"></switchport>
 
+      <switchport-basic operation="remove"><basic></basic></switchport-basic>
       <shutdown operation="remove"></shutdown>
     </{{intf_type}}>
 

--- a/pyswitch/raw/slxos/base/interface.py
+++ b/pyswitch/raw/slxos/base/interface.py
@@ -1,5 +1,8 @@
 from jinja2 import Template
 
+import re
+from xmljson import parker
+import json
 import template
 from pyswitch.raw.base.interface import Interface as BaseInterface
 from pyswitch.utilities import Util
@@ -279,3 +282,153 @@ class Interface(BaseInterface):
         except Exception as e:
             reason = e.message
             raise ValueError(reason)
+
+    def fetch_interfaces_config(self, **kwargs):
+
+        input_intfs = kwargs.get('interfaces', None)
+        if not input_intfs:
+            return True
+
+        intf_dict = {}
+        for item in input_intfs:
+
+            _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
+                                          item['interface'])
+            intf_type = intf_type.strip()
+
+            if intf_type not in intf_dict:
+                intf_dict[intf_type] = []
+
+            intf_dict[intf_type].append(port.strip())
+
+        configs = []
+
+        for k, v in intf_dict.iteritems():
+
+            interface_names = ''
+            for port in v:
+                interface_names = interface_names + "name=\'" + port + '\' or '
+
+            if len(interface_names) > 4:
+                interface_names = interface_names[0:-4]
+
+                t = Template(template.interfaces_config_get)
+                config = t.render(intf_type=k, interface_names=interface_names)
+                config = ' '.join(config.split())
+                configs.append(config)
+
+        def get_dict(d, result_dict):
+
+            for key, val in d.iteritems():
+                new_key = key.split('}')[-1]
+
+                if isinstance(val, dict):
+                    result_dict[new_key] = {}
+                    get_dict(val, result_dict[new_key])
+                elif isinstance(val, list):
+                    result_dict[new_key] = []
+                    for item in val:
+                        result_dict[new_key].append({})
+                        get_dict(item, result_dict[new_key][-1])
+                else:
+                    result_dict[new_key] = val
+
+        result = []
+        for c in configs:
+            try:
+                rpc_response = self._callback(c, handler='get')
+
+                rsp_elem = None
+                for elem in rpc_response.iter():
+                    if elem.tag.split('}')[-1] == 'interface':
+                        rsp_elem = elem
+                        break
+
+                if rsp_elem:
+                    pd = parker.data(rsp_elem)
+                    resp = json.dumps(pd)
+                    resp = json.loads(resp)
+                    c_result_dict = {}
+                    get_dict(resp, c_result_dict)
+                    result.append(c_result_dict)
+            except Exception as err:
+                print err
+
+        return result
+
+    def single_interface_config(self, interface, parameters):
+
+        parameters.pop('interfaces', None)
+
+        if interface['ip'] == 'unnumbered':
+            raise ValueError('Configuring IP unnumbered on interface '
+                             'is not supported on slxos')
+
+        user_data = {'ip': interface['ip'],
+                     'rbridge_id': interface['rbridge_id']}
+
+        _, intf_type, port = re.split('([a-zA-Z]_?[a-zA-Z]*)',
+                                      interface['interface'])
+        if intf_type != 've':
+            user_data['port'] = port.strip()
+            user_data['intf_type'] = intf_type.strip()
+            user_data.update(parameters)
+
+            # configure interface params
+            if intf_type == 'loopback':
+
+                # This is limitation with switch, hence spliting
+                # loopback creation and admin state seperately.
+                t = Template(template.interfaces_loopback_ip_config_set)
+                config = t.render(**user_data)
+                config = ' '.join(config.split())
+                self._callback(config)
+
+                t = Template(template.interfaces_loopback_noshut_config_set)
+            else:
+                t = Template(template.interfaces_config_set)
+
+            config = t.render(**user_data)
+            config = ' '.join(config.split())
+            self._callback(config)
+        return True
+
+    def validate_ipfabric_params(self, parameters):
+        mtu = parameters.get('mtu', None)
+        ip_mtu = parameters.get('ip_mtu', None)
+        ipv6_mtu = parameters.get('ipv6_mtu', None)
+        bfd_multiplier = parameters.get('bfd_multiplier', None)
+        bfd_rx = parameters.get('bfd_rx', None)
+        bfd_tx = parameters.get('bfd_tx', None)
+
+        if not mtu or int(mtu) < 1548 and int(mtu) > 9216:
+            raise ValueError("Invalid mtu: {}. Valid mtu range is 1548-9216"
+                             .format(mtu))
+
+        if not ip_mtu or int(ip_mtu) < 1300 and int(ip_mtu) > 9194:
+            raise ValueError("Invalid ip_mtu: {}. Valid ip_mtu range is "
+                             "1300-9194".format(ip_mtu))
+
+        if not ipv6_mtu or int(ipv6_mtu) < 1300 and int(ipv6_mtu) > 9194:
+            raise ValueError("Invalid ipv6_mtu: {}. Valid ipv6_mtu range is "
+                             "1300-9194".format(ipv6_mtu))
+
+        if bfd_multiplier:
+            if int(bfd_multiplier) < 3 and int(bfd_multiplier) > 50:
+                raise ValueError("Invalid bfd_multiplier: {}. Valid "
+                                 "bfd_multiplier range is 3-50"
+                                 .format(bfd_multiplier))
+
+        if bfd_rx:
+            if int(bfd_rx) < 50 and int(bfd_rx) > 30000:
+                raise ValueError("Invalid bfd_rx: {}. Valid "
+                                 "bfd_rx range is 50-30000"
+                                 .format(bfd_rx))
+
+        if bfd_tx:
+            if int(bfd_tx) < 50 and int(bfd_tx) > 30000:
+                raise ValueError("Invalid bfd_tx: {}. Valid "
+                                 "bfd_tx range is 50-30000"
+                                 .format(bfd_tx))
+
+        return True

--- a/pyswitch/raw/slxos/base/template.py
+++ b/pyswitch/raw/slxos/base/template.py
@@ -166,6 +166,12 @@ interfaces_config_set = """
       <mtu>{{mtu}}</mtu>
       <switchport-basic operation="remove"><basic></basic></switchport-basic>
 
+      <ipv6>
+        <ipv6-config xmlns="urn:brocade.com:mgmt:brocade-ipv6-config">
+          <mtu>{{ipv6_mtu}}</mtu>
+        </ipv6-config>
+      </ipv6>
+
       <ip>
         <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
           <address>

--- a/pyswitch/raw/slxos/base/template.py
+++ b/pyswitch/raw/slxos/base/template.py
@@ -137,3 +137,84 @@ set_intf_admin_state = """
       </interface>
 </config>
 """
+
+interfaces_config_get = """
+<get-config> <source> <running/> </source>
+  <nc:filter type="xpath" select="//{{intf_type}}[{{interface_names}}]"></nc:filter>
+</get-config>
+"""
+
+
+interfaces_config_set = """
+<config>
+  <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+
+    <{{intf_type}}>
+      <name>{{port}}</name>
+
+
+      {% if bfd_tx is not none %}
+        <bfd>
+                <interval>
+                    <min-tx>{{bfd_tx}}</min-tx>
+                    <min-rx>{{bfd_rx}}</min-rx>
+                    <multiplier>{{bfd_multiplier}}</multiplier>
+                </interval>
+        </bfd>
+      {% endif %}
+
+      <mtu>{{mtu}}</mtu>
+      <switchport-basic operation="remove"><basic></basic></switchport-basic>
+
+      <ip>
+        <ip-config xmlns="urn:brocade.com:mgmt:brocade-ip-config">
+          <address>
+            <address>{{ip}}</address>
+          </address>
+
+          <mtu>{{ip_mtu}}</mtu>
+          <proxy-arp></proxy-arp>
+          </ip-config>
+      </ip>
+      <shutdown operation="remove"></shutdown>
+    </{{intf_type}}>
+
+  </interface>
+</config>
+"""
+
+interfaces_loopback_ip_config_set = """
+<config>
+  <routing-system xmlns="urn:brocade.com:mgmt:brocade-common-def">
+
+    <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+        <loopback xmlns="urn:brocade.com:mgmt:brocade-intf-loopback">
+          <id>{{port}}</id>
+          <ip xmlns="urn:brocade.com:mgmt:brocade-ip-config">
+            <ip-config >
+              <address> <address>{{ip}}</address> </address>
+            </ip-config>
+          </ip>
+        </loopback>
+    </interface>
+
+  </routing-system>
+</config>
+"""
+
+interfaces_loopback_noshut_config_set = """
+<config>
+  <routing-system xmlns="urn:brocade.com:mgmt:brocade-common-def">
+
+    <interface xmlns="urn:brocade.com:mgmt:brocade-interface">
+        <loopback xmlns="urn:brocade.com:mgmt:brocade-intf-loopback">
+
+          <id>{{port}}</id>
+          <shutdown operation="remove"></shutdown>
+
+        </loopback>
+    </interface>
+
+  </routing-system>
+</config>
+"""


### PR DESCRIPTION
Below netconf templates are added to configure the interface properties:
1. mtu
2. ip_mtu
3. bfd interval
4. ip address (unnumbered also)
5. ip proxy-arp
6. ipv6_mtu (SLX only)
7. fabric isl enable (VDX only)
8. fabric trunk enable (VDX only)
9. fabric neighbor discovery disable (VDX only)
10. no switchport
11. no shutdown
12. Loopback creation
