### PR TITLE
CANDY-1127

### DIFF
--- a/pyswitch/raw/nos/base/acl/acl.py
+++ b/pyswitch/raw/nos/base/acl/acl.py
@@ -570,6 +570,11 @@ class Acl(SlxNosAcl):
         user_data = {}
         user_data['rbridge_id'] = self.ap.parse_rbridge_id(**kwargs)
         user_data['intf_type'] = self.ap.parse_intf_type(**kwargs)
+        if user_data['intf_type'].lower() == 've' and \
+                not user_data['rbridge_id']:
+            raise ValueError("rbridge_id is a mandatory parameter to apply "
+                             "access-list on ve interface")
+
         user_data['interface_list'] = self.ap.parse_intf_names(**kwargs)
         user_data['acl_name'] = self.ap.parse_acl_name(**kwargs)
         user_data['acl_direction'] = self.ap.parse_acl_direction(**kwargs)


### PR DESCRIPTION
Added a meaningful error for access-list configuration on Ve interface when
rbrid-id was not provided.

Action:
--------
st2 run network_essentials.apply_acl mgmt_ip=10.20.61.37 acl_name=xyz  intf_type=ve intf_name=999 acl_direction=in rbridge_id=37

Verified:
---------
show running-config rbridge-id interface Ve 999
rbridge-id 37
 interface Ve 999
  ipv6 access-group xyz in
  shutdown
 !
!

Action:
--------
st2 run network_essentials.apply_acl mgmt_ip=10.20.61.37 acl_name=xyz  intf_type=ve intf_name=999 acl_direction=in

Verified:
---------
Traceback (most recent call last):
  File "/opt/stackstorm/runners/python_runner/python_runner/python_action_wrapper.py", line 316, in <module>
    obj.run()
  File "/opt/stackstorm/runners/python_runner/python_runner/python_action_wrapper.py", line 178, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/network_essentials/actions/apply_acl.py", line 18, in run
    acl_direction, traffic_type)
  File "/home/svivek/Workspace/network_essentials/actions/ne_base.py", line 1098, in wrapper
    return func(*args, **kwds)
  File "/opt/stackstorm/packs/network_essentials/actions/apply_acl.py", line 49, in switch_operation
    output = device.acl.apply_acl(**parameters)
  File "/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/raw/nos/base/acl/acl.py", line 461, in apply_acl
    user_data = self._parse_params_for_apply_or_remove_acl(**kwargs)
  File "/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/raw/nos/base/acl/acl.py", line 575, in _parse_params_for_apply_or_remove_acl
    raise ValueError("rbridge_id is a mandatory parameter to apply "
ValueError: rbridge_id is a mandatory parameter to apply access-list on ve interface
