### PR TITLE
MLX-395 - Fix the range checks for ping size and timeout

### DIFF
--- a/pyswitch/os/base/utils.py
+++ b/pyswitch/os/base/utils.py
@@ -175,11 +175,16 @@ class Utils(object):
         targets = kwargs.pop('targets', None)
         vrf = kwargs.pop('vrf', 'default-vrf')
         count = kwargs.pop('count', 4)
-        timeout_value = kwargs.pop('timeout_value', 10)
-        if not timeout_value:
-            timeout_value = 10
+        timeout_value = kwargs.pop('timeout_value', 1)
+        if timeout_value is None:
+            timeout_value = 1
+        if timeout_value < 1 or timeout_value > 60:
+            raise AttributeError("Invalid timeout value. Valid range 1 to 60")
         size = kwargs.pop('size', 56)
-
+        if size is None:
+            size = 56
+        if size < 36 or size > 9100:
+            raise AttributeError("Invalid size - valid range 36 to 9100")
         opt = {'device_type': 'brocade_vdx'}
         opt['ip'] = self._host
         opt['username'] = self._auth[0]

--- a/pyswitch/snmp/mlx/base/utils.py
+++ b/pyswitch/snmp/mlx/base/utils.py
@@ -57,17 +57,17 @@ class Utils(BaseUtils):
 
                 if valid_address.version == 4:
                     if vrf != 'default-vrf':
-                        cli = "ping vrf {} {} count {} datagram-size {} timeout {}".format(
+                        cli = "ping vrf {} {} count {} size {} timeout {}".format(
                             vrf, numips, count, size, timeout_value)
                     else:
-                        cli = "ping {} count {} datagram-size {} timeout {}".format(
+                        cli = "ping {} count {} size {} timeout {}".format(
                             numips, count, size, timeout_value)
                 elif valid_address.version == 6:
                     if vrf != 'default-vrf':
-                        cli = "ping ipv6 vrf {} {} count {} datagram-size {} timeout {}".format(
+                        cli = "ping ipv6 vrf {} {} count {} size {} timeout {}".format(
                             vrf, numips, count, size, timeout_value)
                     else:
-                        cli = "ping ipv6 {} count {} datagram-size {} timeout {}".format(
+                        cli = "ping ipv6 {} count {} size {} timeout {}".format(
                             numips, count, size, timeout_value)
 
                 cli_cmd.append(cli)
@@ -172,10 +172,16 @@ class Utils(BaseUtils):
         targets = kwargs.pop('targets', None)
         vrf = kwargs.pop('vrf', 'default-vrf')
         count = kwargs.pop('count', 4)
-        timeout_value = kwargs.pop('timeout_value', 50)
-        if not timeout_value:
-            timeout_value = 50
-        size = kwargs.pop('size', 56)
+        timeout_value = kwargs.pop('timeout_value', 5000)
+        if timeout_value is None:
+            timeout_value = 5000
+        if timeout_value < 50:
+            raise AttributeError("Minimum timeout value is 50")
+        size = kwargs.pop('size', 16)
+        if size is None:
+            size = 16
+        if size > 31954:
+            raise AttributeError("Invalid size - valid range 0 to 31954")
         try:
             cli_list = self._create_ping_cmd(targets, vrf, count, timeout_value, size)
             cli_output = self._execute_cli(cli_list)


### PR DESCRIPTION
Tests:
```
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.12.106 targets=10.17.113.185  vrf=default-vrf size=31955
...
id: 5abb36cabb0f18390278986f
status: failed
parameters: 
  mgmt_ip: 10.24.12.106
  size: 31955
  targets:
  - 10.17.113.185
  vrf: default-vrf
result: 
  exit_code: 0
  result:
    reason: Invalid size - valid range 0 to 31954
    reason_code: 1
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.12.106 targets=10.17.113.185  vrf=default-vrf timeout_value=0
..
id: 5abb36e9bb0f183902789872
status: failed
parameters: 
  mgmt_ip: 10.24.12.106
  targets:
  - 10.17.113.185
  timeout_value: 0
  vrf: default-vrf
result: 
  exit_code: 0
  result:
    reason: Minimum timeout value is 50
    reason_code: 1
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.12.106 targets=10.17.113.185  vrf=default-vrf timeout_value=49
..
id: 5abb36f6bb0f183902789875
status: failed
parameters: 
  mgmt_ip: 10.24.12.106
  targets:
  - 10.17.113.185
  timeout_value: 49
  vrf: default-vrf
result: 
  exit_code: 0
  result:
    reason: Minimum timeout value is 50
    reason_code: 1
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$ st2 run network_essentials.ping_vrf_targets mgmt_ip=10.24.12.106 targets=10.17.113.185  vrf=default-vrf 
...
id: 5abb36ffbb0f183902789878
status: succeeded
parameters: 
  mgmt_ip: 10.24.12.106
  targets:
  - 10.17.113.185
  vrf: default-vrf
result: 
  exit_code: 0
  result:
    ping_output:
    - ip_address: 10.17.113.185
      packet loss: 0%
      packets received: 4
      packets transmitted: 4
      result: pass
    reason_code: 0
  stderr: 'st2.actions.python.CheckPing: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.restproto)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.user)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.passwd)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.enablepass)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.ostype)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpver)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpport)
    st2.actions.python.CheckPing: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.106.snmpv2c)
    '
  stdout: ''
ubuntu@bwcvagrant:~$ 

```