### PR TITLE
Reserved VLAN  is not required NI  MLX-399

### DIFF
--- a/pyswitch/utilities.py
+++ b/pyswitch/utilities.py
@@ -374,11 +374,7 @@ def expand_vlan_range(vlan_id):
             extended = "false"
 
         tmp_vlan_id = valid_vlan_id(vid, extended=extended)
-
-        reserved_vlan_list = range(4087, 4096)
         if not tmp_vlan_id:
-            return None
-        elif vid in reserved_vlan_list:
             return None
 
     return vlan_id


### PR DESCRIPTION
$  st2 run network_essentials.create_switchport_trunk intf_type=ethernet mgmt_ip=10.20.179.147 intf_name=1/9 vlan_id=4090
...
id: 5abe8423c4da5f04c308225f
status: succeeded
parameters: 
  intf_name: 1/9
  intf_type: ethernet
  mgmt_ip: 10.20.179.147
  vlan_id: '4090'
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.CreateSwitchPort: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.passwd)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)
    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.20.179.147 to create switchport on Interface
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 1/9
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface
    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.20.179.147 after configuring switch port on interface -- all done!
    '
  stdout: ''
vagrant ~
$  st2 run network_essentials.create_switchport_trunk intf_type=ethernet mgmt_ip=10.20.179.147 intf_name=1/9 vlan_id=101-103,2
...
id: 5abe8470c4da5f04c3082262
status: succeeded
parameters: 
  intf_name: 1/9
  intf_type: ethernet
  mgmt_ip: 10.20.179.147
  vlan_id: 101-103,2
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.CreateSwitchPort: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.passwd)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)
    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.20.179.147 to create switchport on Interface
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 1/9
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface
    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.20.179.147 after configuring switch port on interface -- all done!
    '
  stdout: ''
vagrant ~
$  st2 run network_essentials.remove_switchport_trunk_allowed_vlan intf_type=ethernet mgmt_ip=10.20.179.147 intf_name=1/9 vlan_id=101-103,2
..
id: 5abe84a1c4da5f04c3082265
status: succeeded
parameters: 
  intf_name: 1/9
  intf_type: ethernet
  mgmt_ip: 10.20.179.147
  vlan_id: 101-103,2
result: 
  exit_code: 0
  result:
    switchport_doesnot_exists: true
    switchport_trunk_config: true
  stderr: 'st2.actions.python.RemoveSwitchPort: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.passwd)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)
    st2.actions.python.RemoveSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)
    st2.actions.python.RemoveSwitchPort: INFO     successfully connected to 10.20.179.147 to Remove switchport trunk allowed vlan on the Interface
    st2.actions.python.RemoveSwitchPort: INFO     Removing Switch port trunk allowed vlan 101-103,2
    st2.actions.python.RemoveSwitchPort: INFO     closing connection to 10.20.179.147 after Removing the switch port trunk allowed vlan on interface -- all done!
    '
  stdout: ''
vagrant ~
$ 
VDX log
$  st2 run network_essentials.create_switchport_trunk  mgmt_ip=10.24.81.206 intf_name=206/0/5 vlan_id=4090
......
id: 5abea3ccc4da5f04c3082276
status: failed
parameters: 
  intf_name: 206/0/5
  mgmt_ip: 10.24.81.206
  vlan_id: '4090'
result: 
  exit_code: 1
  result: None
  stderr: "st2.actions.python.CreateSwitchPort: DEBUG    Creating new Client object.
No handlers could be found for logger "st2.st2common.util.api"
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.restproto)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.passwd)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.enablepass)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.ostype)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpver)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpport)
st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpv2c)
st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.81.206 to create switchport on Interface
st2.actions.python.CreateSwitchPort: INFO     User provided vlans contains reserved vlans 4090
st2.actions.python.CreateSwitchPort: INFO     Disabling isl on tengigabitethernet 206/0/5
st2.actions.python.CreateSwitchPort: INFO     Disabling fabric trunk on tengigabitethernet 206/0/5
st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 206/0/5
st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface
st2.actions.python.CreateSwitchPort: ERROR    Configuring Switch port trunk vlans failed due to NSM_API_ERR_VLAN_NOT_CONFIGURED | % Error: VLAN not configured or has rspan-vlan configuration
Traceback (most recent call last):
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 243, in _switchport_vlans
    vlan=vlan_id)
  File "/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/os/base/interface.py", line 1168, in trunk_allowed_vlan
    return callback(config)
  File "/opt/stackstorm/virtualenvs/network_essentials/lib/python2.7/site-packages/pyswitch/RestDevice.py", line 365, in _callback_main
    raise ValueError(op)
ValueError: NSM_API_ERR_VLAN_NOT_CONFIGURED | % Error: VLAN not configured or has rspan-vlan configuration
st2.actions.python.CreateSwitchPort: ERROR    Error encountered on 10.24.81.206 due to Configuring Switch port trunk vlans failed
Traceback (most recent call last):
  File "/home/vagrant/bwc/network_essentials/actions/ne_base.py", line 1100, in wrapper
    return func(*args, **kwds)
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 91, in switch_operation
    v_list, c_list)
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 253, in _switchport_vlans
    raise ValueError("Configuring Switch port trunk vlans failed")
ValueError: Configuring Switch port trunk vlans failed
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 278, in <module>
    obj.run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 171, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 44, in run
    trunk_no_default_native)
  File "/home/vagrant/bwc/network_essentials/actions/ne_base.py", line 1100, in wrapper
    return func(*args, **kwds)
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 91, in switch_operation
    v_list, c_list)
  File "/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py", line 253, in _switchport_vlans
    raise ValueError("Configuring Switch port trunk vlans failed")
ValueError: Configuring Switch port trunk vlans failed
"
  stdout: ''
vagrant ~
$  st2 run network_essentials.create_switchport_trunk  mgmt_ip=10.24.81.206 intf_name=206/0/5 vlan_id=10
......
id: 5abea423c4da5f04c3082279
status: succeeded
parameters: 
  intf_name: 206/0/5
  mgmt_ip: 10.24.81.206
  vlan_id: '10'
result: 
  exit_code: 0
  result:
    disable_fabric_trunk: true
    disable_isl: true
    switchport_doesnot_exists: true
    switchport_trunk_config: true
    switchport_trunk_vlan_config: true
  stderr: 'st2.actions.python.CreateSwitchPort: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.restproto)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.passwd)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.enablepass)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.ostype)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpver)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpport)
    st2.actions.python.CreateSwitchPort: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpv2c)
    st2.actions.python.CreateSwitchPort: INFO     Successfully connected to 10.24.81.206 to create switchport on Interface
    st2.actions.python.CreateSwitchPort: INFO     Disabling isl on tengigabitethernet 206/0/5
    st2.actions.python.CreateSwitchPort: INFO     Disabling fabric trunk on tengigabitethernet 206/0/5
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport mode as `trunk` on the interface 206/0/5
    st2.actions.python.CreateSwitchPort: INFO     Configuring switchport trunk vlan on the interface
    st2.actions.python.CreateSwitchPort: INFO     Closing connection to 10.24.81.206 after configuring switch port on interface -- all done!
    '
  stdout: ''
vagrant ~
$ st2 run network_essentials.create_vlan mgmt_ip=10.20.179.147 vlan_id=4089.
id: 5abea5a5c4da5f04c308227c
status: succeeded
parameters: 
  mgmt_ip: 10.20.179.147
  vlan_id: '4089'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.passwd)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.179.147 to create interface vlans
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: INFO     Closing connection to 10.20.179.147 after creating vlan -- all done!
    '
  stdout: ''
vagrant ~
$ st2 run network_essentials.create_vlan mgmt_ip=10.24.81.206 vlan_id=4089
..
id: 5abea5c0c4da5f04c308227f
status: failed
parameters: 
  mgmt_ip: 10.24.81.206
  vlan_id: '4089'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.passwd)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.81.206 to create interface vlans
    st2.actions.python.CreateVlan: INFO     User provided vlans contains reserved vlans 4089
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: ERROR    VLAN creation failed due to NSM_RES_VLAN_ERR_VLAN_IS_RES | % Error: One or more specified vlan(s) is a reserved vlan(s)
    '
  stdout: ''
vagrant ~
$ st2 run network_essentials.create_vlan mgmt_ip=10.24.12.95 vlan_id=4089
..
id: 5abea5edc4da5f04c3082282
status: succeeded
parameters: 
  mgmt_ip: 10.24.12.95
  vlan_id: '4089'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.passwd)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.12.95.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.12.95 to create interface vlans
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: INFO     Closing connection to 10.24.12.95 after creating vlan -- all done!
    '
  stdout: ''
vagrant ~
$ st2 run network_essentials.create_vlan mgmt_ip=10.24.81.206 vlan_id=4097
..
id: 5abea609c4da5f04c3082285
status: succeeded
parameters: 
  mgmt_ip: 10.24.81.206
  vlan_id: '4097'
result: 
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.passwd)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.24.81.206.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.24.81.206 to create interface vlans
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: INFO     Closing connection to 10.24.81.206 after creating vlan -- all done!
    '
  stdout: ''
vagrant ~
$ st2 run network_essentials.create_vlan mgmt_ip=10.20.179.147 vlan_id=4091
.
id: 5abea619c4da5f04c3082288
status: failed
parameters: 
  mgmt_ip: 10.20.179.147
  vlan_id: '4091'
result: 
  exit_code: 255
  result: None
  stderr: 'st2.actions.python.CreateVlan: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.restproto)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.user)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.passwd)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.enablepass)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.ostype)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpver)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpport)
    st2.actions.python.CreateVlan: DEBUG    Retrieving value from the datastore (name=switch.10.20.179.147.snmpv2c)
    st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.179.147 to create interface vlans
    st2.actions.python.CreateVlan: INFO     Creating Vlans
    st2.actions.python.CreateVlan: ERROR    VLAN creation failed due to "4091" is out of range.
    '
  stdout: ''
vagrant ~
$ 
