### PR TITLE
Fixing typo error in temnplate file.

### DIFF
--- a/pyswitch/raw/nos/base/acl/acl_template.py
+++ b/pyswitch/raw/nos/base/acl/acl_template.py
@@ -273,7 +273,6 @@ acl_rule_ip_bulk = """
                 {% if ud.source.host_any != "any" %}
                   {% if ud.source.host_any == "host" %}
                     <src-host-ip>{{ud.source.host_ip}}</src-host-ip>
-                  {% elif address_type == "ip" %}
                   {% elif ud.source.mask is not none %}
                     <src-mask>{{ud.source.mask}}</src-mask>
                   {% endif %}


### PR DESCRIPTION
Verified that action is working.

Action:
--------
st2 run network_essentials.add_ipv4_rule_acl mgmt_ip=10.20.61.41 acl_name=new_ip_acl1 acl_rules='[{"action": "permit", "source": "4.47.0.0/0.255.255.255 eq bootps","destination":"9.57.0.0/0.0.255.255 lt snmp","protocol_type":"udp" ,"seq_id":118}]'

Verified:
---------
id: 5ac1d791e3c93b604f85ed0e
status: succeeded
parameters:
  acl_name: new_ip_acl1
  acl_rules:
  - action: permit
    destination: 9.57.0.0/0.0.255.255 lt snmp
    protocol_type: udp
    seq_id: 118
    source: 4.47.0.0/0.255.255.255 eq bootps
  mgmt_ip: 10.20.61.41
