### PR TITLE
idempotent check for ip numbered

### DIFF
--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -363,7 +363,7 @@ class Interface(BaseInterface):
                 if err_str in e.message:
                     print err_str, user_data['port']
                 else:
-                    raise Exception(e.message)
+                    raise Exception(e.message, user_data['port'])
         return True
 
     def validate_ipfabric_params(self, parameters):

--- a/pyswitch/raw/nos/base/interface.py
+++ b/pyswitch/raw/nos/base/interface.py
@@ -355,7 +355,15 @@ class Interface(BaseInterface):
 
             config = t.render(**user_data)
             config = ' '.join(config.split())
-            self._callback(config)
+            try:
+                self._callback(config)
+            except Exception as e:
+                err_str = 'IP Unnumbered interface configuration is already '\
+                          'done on this interface'
+                if err_str in e.message:
+                    print err_str, user_data['port']
+                else:
+                    raise Exception(e.message)
         return True
 
     def validate_ipfabric_params(self, parameters):


### PR DESCRIPTION
If the interface is pre-configured with ip numbered, re-running the action will attempt to re-configure and action fails due to 'NSM_ERR_IPUNNUMBERED_ALREADY_CONFIGURED | %Error: IP Unnumbered interface configuration is already done on this interface.' . there is no check to catch this exception which subsequently fails the action . 

Added a check to catch this exception and print the message.  The check is only added for ip numbered. 

Previous Behavior
-------------------
[root@win7test vagrant]# st2 run dcfabric.configure_intfs_ipfabric host=10.37.18.166 interfaces='[{"interface":"tengigabitethernet1/1/1", "ip":"unnumbered", "rbridge_id":"1", "donor":"loopback1"}]' bfd_tx=50 bfd_rx=100 bfd_multiplier=10
..
id: 5ad6d9cfc40775300a429570
status: failed
parameters:
  bfd_multiplier: '10'
  bfd_rx: '100'
  bfd_tx: '50'
  host: 10.37.18.166
  interfaces:
  - donor: loopback1
    interface: tengigabitethernet1/1/1
    ip: unnumbered
    rbridge_id: '1'
result:
  exit_code: 0
  result:
    tengigabitethernet1/1/1: "Traceback (most recent call last):
  File "/opt/stackstorm/packs/dcfabric/actions/configure_intfs_ipfabric.py", line 66, in run
    output = device.interface.single_interface_config(item, parameters)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/pyswitch/raw/nos/base/interface.py", line 358, in single_interface_config
    self._callback(config)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/pyswitch/NetConfDevice.py", line 231, in _callback_main
    self._mgr.edit_config(target=target, config=call)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/ncclient/manager.py", line 162, in wrapper
    return self.execute(op_cls, *args, **kwds)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/ncclient/manager.py", line 232, in execute
    raise_mode=self._raise_mode).request(*args, **kwds)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/ncclient/operations/edit.py", line 67, in request
    return self._request(node)
  File "/opt/stackstorm/virtualenvs/dcfabric/lib/python2.7/site-packages/ncclient/operations/rpc.py", line 337, in _request
    raise self._reply.error
RPCError: NSM_ERR_IPUNNUMBERED_ALREADY_CONFIGURED | %Error: IP Unnumbered interface configuration is already done on this interface.
"
  stderr: 'st2.actions.python.ConfigureIp: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.ConfigureIp: DEBUG    Retrieving value from the datastore (name=switch.10.37.18.166.restproto)
    st2.actions.python.ConfigureIp: INFO     HOST: 10.37.18.166 Configuring Interface: {u''interface'': u''tengigabitethernet1/1/1'', u''ip'': u''unnumbered'', u''rbridge_id'': u''1'', u''donor'': u''loopback1''}
    st2.actions.python.ConfigureIp: INFO     closing connection to 10.37.18.166 -- all done!
    '


Post fix behavior
------------------

[root@win7test vagrant]# st2 run dcfabric.configure_intfs_ipfabric host=10.37.18.166 interfaces='[{"interface":"tengigabitethernet1/1/1", "ip":"unnumbered", "rbridge_id":"1", "donor":"loopback1"}]' bfd_tx=50 bfd_rx=100 bfd_multiplier=10
..
id: 5ad6f6bac40775300a4295f1
status: succeeded
parameters:
  bfd_multiplier: '10'
  bfd_rx: '100'
  bfd_tx: '50'
  host: 10.37.18.166
  interfaces:
  - donor: loopback1
    interface: tengigabitethernet1/1/1
    ip: unnumbered
    rbridge_id: '1'
result:
  exit_code: 0
  result: true
  stderr: 'st2.actions.python.ConfigureIp: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.ConfigureIp: DEBUG    Retrieving value from the datastore (name=switch.10.37.18.166.restproto)
    st2.actions.python.ConfigureIp: INFO     HOST: 10.37.18.166 Configuring Interface: {u''interface'': u''tengigabitethernet1/1/1'', u''ip'': u''unnumbered'', u''rbridge_id'': u''1'', u''donor'': u''loopback1''}
    st2.actions.python.ConfigureIp: INFO     closing connection to 10.37.18.166 -- all done!
    '
  stdout: 'IP Unnumbered interface configuration is already done on this interface 1/1/1
    '
[root@win7test vagrant]#

Array of inputs  
----------------

[root@win7test vagrant]# st2 run dcfabric.configure_intfs_ipfabric host=10.37.18.166 interfaces='[{"interface":"tengigabitethernet1/1/1", "ip":"unnumbered", "rbridge_id":"1", "donor":"loopback1"}, {"interface":"tengigabitethernet1/1/3", "ip":"3.1.1.1/22", "rbridge_id":"1", "donor":null}, {"interface":"loopback20", "ip":"13.1.1.10/32", "rbridge_id":"1", "donor":null}]' bfd_tx=50 bfd_rx=100 bfd_multiplier=10
..
id: 5ad6f75ec40775300a4295f4
status: succeeded
parameters:
  bfd_multiplier: '10'
  bfd_rx: '100'
  bfd_tx: '50'
  host: 10.37.18.166
  interfaces:
  - donor: loopback1
    interface: tengigabitethernet1/1/1
    ip: unnumbered
    rbridge_id: '1'
  - donor: null
    interface: tengigabitethernet1/1/3
    ip: 3.1.1.1/22
    rbridge_id: '1'
  - donor: null
    interface: loopback20
    ip: 13.1.1.10/32
    rbridge_id: '1'
result:
  exit_code: 0
  result: true
  stderr: 'st2.actions.python.ConfigureIp: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.ConfigureIp: DEBUG    Retrieving value from the datastore (name=switch.10.37.18.166.restproto)
    st2.actions.python.ConfigureIp: INFO     HOST: 10.37.18.166 Configuring Interface: {u''interface'': u''tengigabitethernet1/1/1'', u''ip'': u''unnumbered'', u''rbridge_id'': u''1'', u''donor'': u''loopback1''}
    st2.actions.python.ConfigureIp: INFO     HOST: 10.37.18.166 Configuring Interface: {u''interface'': u''tengigabitethernet1/1/3'', u''ip'': u''3.1.1.1/22'', u''rbridge_id'': u''1'', u''donor'': None}
    st2.actions.python.ConfigureIp: INFO     HOST: 10.37.18.166 Configuring Interface: {u''interface'': u''loopback20'', u''ip'': u''13.1.1.10/32'', u''rbridge_id'': u''1'', u''donor'': None}
    st2.actions.python.ConfigureIp: INFO     closing connection to 10.37.18.166 -- all done!
    '
  stdout: 'IP Unnumbered interface configuration is already done on this interface 1/1/1
    '
[root@win7test vagrant]#
