### PR TITLE
Added a check for 'null' keyword which was sent by EFO.

### DIFF
--- a/pyswitch/raw/slx_nos/acl/macacl.py
+++ b/pyswitch/raw/slx_nos/acl/macacl.py
@@ -193,6 +193,9 @@ class MacAcl(AclParamParser):
 
     def parse_vlan_id(self, vlan):
 
+        if vlan == 'null':
+            return None
+
         if vlan == "any":
             return vlan
 


### PR DESCRIPTION
This change is required because in drop_provision workflow we
started typecasting vlan to string which was earlier integer.
typecasting of 'null' keyword to string created a valid
python string containing value 'null'. Hence need to add a check
to ignore this.