### PR TITLE
Get acl rules branch py switch

### DIFF
--- a/pyswitch/raw/base/acl.py
+++ b/pyswitch/raw/base/acl.py
@@ -498,3 +498,19 @@ class Acl(object):
                                                 seq_id='all')
         """
         return
+
+    @abc.abstractmethod
+    def resequence_acl_rules(self, **kwargs):
+        """
+        Returns the number of congiured rules
+        Args:
+            acl_name (str): Name of the access list.
+        Returns:
+            Number of rules configured,
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.resequence_acl_rules(acl_name='Acl_1')
+        """
+        return

--- a/pyswitch/raw/slx_nos/acl/acl.py
+++ b/pyswitch/raw/slx_nos/acl/acl.py
@@ -649,6 +649,9 @@ class SlxNosAcl(BaseAcl):
         for r in rules_list:
             self._decorate_ip_source(r)
             self._decorate_ip_destination(r)
+            for k,v in r.iteritems():
+                if isinstance(v, int) or isinstance(v, bool):
+                    r[k] = str(v)
 
     def _decorate_ip_source(self, rule):
         if 'src_host_any_sip' in rule:

--- a/pyswitch/raw/slx_nos/acl/acl.py
+++ b/pyswitch/raw/slx_nos/acl/acl.py
@@ -637,8 +637,144 @@ class SlxNosAcl(BaseAcl):
             rules_list = self._get_acl_rules(rest_device.device_type,
                                              address_type, acl_type, acl_name,
                                              seq_range)
+            if address_type == 'ip':
+                self._decorate_ip_rules_list(rules_list)
+
+                
             resp_body = json.dumps(rules_list)
             return resp_body
+
+
+    def _decorate_ip_rules_list(self, rules_list):
+        for r in rules_list:
+            self._decorate_ip_source(r)
+            self._decorate_ip_destination(r)
+
+    def _decorate_ip_source(self, rule):
+        if 'src_host_any_sip' in rule:
+            if 'src_host_ip' in rule:
+                rule['source'] = rule['src_host_any_sip'] + ',' + \
+                    rule['src_host_ip']
+                del rule['src_host_ip']
+            elif 'src_mask' in rule:
+                rule['source'] = rule['src_host_any_sip'] + '/' + \
+                    rule['src_mask']
+                del rule['src_mask']
+            else:
+                rule['source'] = 'any'
+
+            del rule['src_host_any_sip']
+
+        if 'sport' in rule:
+            if rule['sport'] == 'gt':
+                if 'sport_number_gt_tcp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_gt_tcp']
+                    del rule['sport_number_gt_tcp']
+                elif 'sport_number_gt_udp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_gt_udp']
+                    del rule['sport_number_gt_udp']
+            elif rule['sport'] == 'lt':
+                if 'sport_number_lt_tcp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_lt_tcp']
+                    del rule['sport_number_lt_tcp']
+                elif 'sport_number_lt_udp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_lt_udp']
+                    del rule['sport_number_lt_udp']
+            elif rule['sport'] == 'neq' or rule['sport'] == 'eq':
+                if 'sport_number_eq_neq_tcp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_eq_neq_tcp']
+                    del rule['sport_number_eq_neq_tcp']
+                elif 'sport_number_eq_neq_udp' in rule:
+                    rule['source'] += ' ' + rule['sport'] + ' ' + \
+                        rule['sport_number_eq_neq_udp']
+                    del rule['sport_number_eq_neq_udp']
+            elif rule['sport'] == 'range':
+                rule['source'] += ' ' + rule['sport']
+                if 'sport_number_range_lower_tcp' in rule:
+                    rule['source'] += ' ' + rule['sport_number_range_lower_tcp']
+                    del rule['sport_number_range_lower_tcp']
+
+                if 'sport_number_range_higher_tcp' in rule:
+                    rule['source'] += ' ' + rule['sport_number_range_higher_tcp']
+                    del rule['sport_number_range_higher_tcp']
+
+                if 'sport_number_range_lower_udp' in rule:
+                    rule['source'] += ' ' + rule['sport_number_range_lower_udp']
+                    del rule['sport_number_range_lower_udp']
+
+                if 'sport_number_range_higher_udp' in rule:
+                    rule['source'] += ' ' + rule['sport_number_range_higher_udp']
+                    del rule['sport_number_range_higher_udp']
+
+            del rule['sport']
+
+    def _decorate_ip_destination(self, rule):
+        if 'dst_host_any_dip' in rule:
+            if 'dst_host_ip' in rule:
+                rule['destination'] = rule['dst_host_any_dip'] + ',' + \
+                    rule['dst_host_ip']
+                del rule['dst_host_ip']
+            elif 'dst_mask' in rule:
+                rule['destination'] = rule['dst_host_any_dip'] + '/' + \
+                    rule['dst_mask']
+                del rule['dst_mask']
+            else:
+                rule['destination'] = 'any'
+
+            del rule['dst_host_any_dip']
+
+        if 'dport' in rule:
+            if rule['dport'] == 'gt':
+                if 'dport_number_gt_tcp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_gt_tcp']
+                    del rule['dport_number_gt_tcp']
+                elif 'dport_number_gt_udp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_gt_udp']
+                    del rule['dport_number_gt_udp']
+            elif rule['dport'] == 'lt':
+                if 'dport_number_lt_tcp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_lt_tcp']
+                    del rule['dport_number_lt_tcp']
+                elif 'dport_number_lt_udp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_lt_udp']
+                    del rule['dport_number_lt_udp']
+            elif rule['dport'] == 'neq' or rule['dport'] == 'eq':
+                if 'dport_number_eq_neq_tcp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_eq_neq_tcp']
+                    del rule['dport_number_eq_neq_tcp']
+                elif 'dport_number_eq_neq_udp' in rule:
+                    rule['destination'] += ' ' + rule['dport'] + ' ' + \
+                        rule['dport_number_eq_neq_udp']
+                    del rule['dport_number_eq_neq_udp']
+            elif rule['dport'] == 'range':
+                rule['destination'] += ' ' + rule['dport']
+                if 'dport_number_range_lower_tcp' in rule:
+                    rule['destination'] += ' ' + rule['dport_number_range_lower_tcp']
+                    del rule['dport_number_range_lower_tcp']
+
+                if 'dport_number_range_higher_tcp' in rule:
+                    rule['destination'] += ' ' + rule['dport_number_range_higher_tcp']
+                    del rule['dport_number_range_higher_tcp']
+
+                if 'dport_number_range_lower_udp' in rule:
+                    rule['destination'] += ' ' + rule['dport_number_range_lower_udp']
+                    del rule['dport_number_range_lower_udp']
+
+                if 'dport_number_range_higher_udp' in rule:
+                    rule['destination'] += ' ' + rule['dport_number_range_higher_udp']
+                    del rule['dport_number_range_higher_udp']
+
+            del rule['dport']
 
     def resequence_acl_rules(self, **kwargs):
         """

--- a/pyswitch/raw/slx_nos/acl/params_validator.py
+++ b/pyswitch/raw/slx_nos/acl/params_validator.py
@@ -536,3 +536,22 @@ def validate_params_get_acl_rules(**parameters):
         if set(unaccepted_params) != set(st2_specific_params):
             raise ValueError("unaccepted parameters provided: {}"
                              .format(unaccepted_params))
+
+
+def validate_params_slx_nos_resequence_acl_rules(**parameters):
+    required_params = ['acl_name']
+    accepted_params = ['acl_name', 'device']
+    st2_specific_params = []
+
+    received_params = [k for k, v in parameters.iteritems() if v]
+
+    absent_required = list(set(required_params) - set(received_params))
+    if len(absent_required) > 0:
+        raise ValueError("missing required parameters: {}"
+                         .format(absent_required))
+
+    unaccepted_params = list(set(received_params) - set(accepted_params))
+    if len(unaccepted_params) > 0:
+        if set(unaccepted_params) != set(st2_specific_params):
+            raise ValueError("unaccepted parameters provided: {}"
+                             .format(unaccepted_params))

--- a/pyswitch/snmp/base/acl/acl.py
+++ b/pyswitch/snmp/base/acl/acl.py
@@ -503,3 +503,19 @@ class Acl(object):
                                                 seq_id='all')
         """
         return
+
+    @abc.abstractmethod
+    def resequence_acl_rules(self, **kwargs):
+        """
+        Returns the number of congiured rules
+        Args:
+            acl_name (str): Name of the access list.
+        Returns:
+            Number of rules configured,
+        Examples:
+            >>> from pyswitch.device import Device
+            >>> with Device(conn=conn, auth=auth,
+                            connection_type='NETCONF') as dev:
+            >>>     print dev.acl.resequence_acl_rules(acl_name='Acl_1')
+        """
+        return

--- a/pyswitch/snmp/base/acl/params_validator.py
+++ b/pyswitch/snmp/base/acl/params_validator.py
@@ -266,3 +266,22 @@ def validate_params_mlx_get_acl_rules(**parameters):
         if set(unaccepted_params) != set(st2_specific_params):
             raise ValueError("unaccepted parameters provided: {}"
                              .format(unaccepted_params))
+
+
+def validate_params_mlx_resequence_acl_rules(**parameters):
+    required_params = ['acl_name']
+    accepted_params = ['acl_name']
+    st2_specific_params = []
+
+    received_params = [k for k, v in parameters.iteritems() if v]
+
+    absent_required = list(set(required_params) - set(received_params))
+    if len(absent_required) > 0:
+        raise ValueError("missing required parameters: {}"
+                         .format(absent_required))
+
+    unaccepted_params = list(set(received_params) - set(accepted_params))
+    if len(unaccepted_params) > 0:
+        if set(unaccepted_params) != set(st2_specific_params):
+            raise ValueError("unaccepted parameters provided: {}"
+                             .format(unaccepted_params))

--- a/pyswitch/snmp/mlx/base/acl/acl.py
+++ b/pyswitch/snmp/mlx/base/acl/acl.py
@@ -1649,6 +1649,9 @@ class Acl(BaseAcl):
                         config['seq_id'] = rule[index][:-1]
                         index += 1
 
+                        if rule[index] == 'sequence':
+                            index += 2
+
                         config['action'] = rule[index]
                         index += 1
 
@@ -1710,6 +1713,9 @@ class Acl(BaseAcl):
                         config['seq_id'] = rule[index][:-1]
                         index += 1
 
+                        if rule[index] == 'sequence':
+                            index += 2
+
                         config['action'] = rule[index]
                         index += 1
 
@@ -1741,6 +1747,9 @@ class Acl(BaseAcl):
 
                         config['seq_id'] = rule[index][:-1]
                         index += 1
+
+                        if rule[index] == 'sequence':
+                            index += 2
 
                         config['action'] = rule[index]
                         index += 1
@@ -1900,6 +1909,9 @@ class Acl(BaseAcl):
                         config['seq_id'] = rule[index][:-1]
                         index += 1
 
+                        if rule[index] == 'sequence':
+                            index += 2
+
                         config['action'] = rule[index]
                         index += 1
 
@@ -1959,6 +1971,7 @@ class Acl(BaseAcl):
 
                         for j, val in enumerate(rule[index:]):
                             i = index + j
+
                             if val == 'priority-force':
                                 config['priority_force'] = rule[i + 1]
                             elif val == 'priority-mapping':
@@ -2010,9 +2023,14 @@ class Acl(BaseAcl):
                                          'router-advertisement',
                                          'router-renumbering',
                                          'router-solicitation', 'routing',
-                                         'sequence', 'time-exceeded',
+                                         'time-exceeded',
                                          'unreachable']:
                                 config['icmp_filter'] = val
+                            elif val.isdigit():
+                                if 'icmp_filter' not in config:
+                                    config['icmp_filter'] = val
+                                else:
+                                    config['icmp_filter'] += ' ' + val
                         rules_list.append(config)
         return rules_list
 


### PR DESCRIPTION
Changes for get_acl_rules and resequence_acl_rules.

Test Results
--------------
L2 ACL Rule resequencing on MLX platform
------------------------------------------
Before resequncing

L2 MAC Access List pqr : 5 entries
20: permit any any 23 etype ipv6 mirror drop-precedence 1 priority 3
40: permit any any any etype any
50: permit any any any etype any priority-force 3
60: permit any any any etype any log
80: permit any any any etype any drop-precedence-force 2

After resequncing

L2 MAC Access List pqr : 5 entries
10: permit any any 23 etype ipv6 mirror drop-precedence 1 priority 3
20: permit any any any etype any
30: permit any any any etype any priority-force 3
40: permit any any any etype any log
50: permit any any any etype any drop-precedence-force 2

IP ACL Rule resequencing on MLX platform
------------------------------------------
Before resequncing

Extended IP access list abc : 12 entries
10: permit udp 3.2.1.0 0.0.0.255 eq ftp-data any range ftp-data  32
30: permit udp any any tos normal priority-force 3 fragment suppress-rpf-drop mirror match-payload-len
40: permit udp any any precedence flash tos normal priority-force 3 fragment suppress-rpf-drop mirror match-payload-len
60: permit udp any any precedence flash tos normal dscp-marking 3 priority-force 3 fragment suppress-rpf-drop copy-sflow match-payload-len
70: permit udp any any precedence flash tos min-delay dscp-mapping 4 dscp-marking 3 priority-force 3 fragment option extended-security suppress-rpf-drop copy-sflow match-payload-len
80: permit vlan 23 tcp any any
90: permit tcp any any established syn
100: permit icmp 1.1.1.0 0.0.0.255 any host-redirect
110: permit vlan 555 tcp any any eq 30
120: permit vlan 666 tcp 6.6.0.0 0.0.255.255 range ftp ssh any established syn
140: permit vlan 777 tcp 6.6.0.0 0.0.255.255 range ftp ssh 7.7.7.0 0.0.0.255 established syn neq dsp3270 tos normal
150: permit vlan 777 tcp 6.6.0.0 0.0.255.255 range ftp ssh 7.7.7.0 0.0.0.255 established syn neq dsp3270 tos normal suppress-rpf-drop log

After resequncing

Extended IP access list abc : 12 entries
10: permit udp 3.2.1.0 0.0.0.255 eq ftp-data any range ftp-data  32
20: permit udp any any tos normal priority-force 3 fragment suppress-rpf-drop mirror match-payload-len
30: permit udp any any precedence flash tos normal priority-force 3 fragment suppress-rpf-drop mirror match-payload-len
40: permit udp any any precedence flash tos normal dscp-marking 3 priority-force 3 fragment suppress-rpf-drop copy-sflow match-payload-len
50: permit udp any any precedence flash tos min-delay dscp-mapping 4 dscp-marking 3 priority-force 3 fragment option extended-security suppress-rpf-drop copy-sflow match-payload-len
60: permit vlan 23 tcp any any
70: permit tcp any any established syn
80: permit icmp 1.1.1.0 0.0.0.255 any host-redirect
90: permit vlan 555 tcp any any eq 30
100: permit vlan 666 tcp 6.6.0.0 0.0.255.255 range ftp ssh any established syn
110: permit vlan 777 tcp 6.6.0.0 0.0.255.255 range ftp ssh 7.7.7.0 0.0.0.255 established syn neq dsp3270 tos normal
120: permit vlan 777 tcp 6.6.0.0 0.0.255.255 range ftp ssh 7.7.7.0 0.0.0.255 established syn neq dsp3270 tos normal suppress-rpf-drop log

IPv6 ACL Rule resequencing on MLX platform
--------------------------------------------
Before resequncing

ipv6 access-list ACL_IPv6_extended_test: 2 entries
 10: permit tcp any any
 30: permit sctp any any

After resequencing

ipv6 access-list ACL_IPv6_extended_test: 2 entries
 10: permit tcp any any
 20: permit sctp any any

get_acl_rules
----------------
(network_essentials) svivek@svivek-VirtualBox:~/Defects$ st2 run network_essentials.get_acl_rules mgmt_ip=10.18.124.15 acl_name=new_ipv4_acl2
........
id: 5b30d2dbe3c93b496ab4ee1f
status: succeeded
parameters:
  acl_name: new_ipv4_acl2
  mgmt_ip: 10.18.124.15
result:
  exit_code: 0
  result: '[{"count": false, "log": false, "seq_id": 5, "destination": "5.55.0.0/0.0.255.255", "source": "4.44.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}, {"count": false, "log": false, "seq_id": 10, "destination": "5.55.0.0/0.0.255.255", "source": "4.44.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "ip"}, {"count": false, "log": false, "seq_id": 11, "destination": "5.55.0.0/0.0.255.255", "source": "4.45.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "icmp"}, {"count": false, "log": false, "seq_id": 12, "destination": "5.55.0.0/0.0.255.255", "source": "4.46.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": 100}, {"count": false, "urg": false, "log": true, "source": "4.47.0.0/0.0.255.255", "ack": false, "seq_id": 13, "destination": "5.55.0.0/0.0.255.255", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "log": true, "seq_id": 14, "destination": "5.55.0.0/0.0.255.255", "source": "4.48.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}, {"count": false, "log": true, "seq_id": 15, "destination": "5.56.0.0/0.0.255.255", "source": "4.48.0.0/0.0.255.255", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}, {"count": false, "log": false, "seq_id": 20, "destination": "host,6.55.0.1", "source": "host,5.55.0.1", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}, {"count": false, "log": false, "seq_id": 31, "destination": "host,5.55.0.1", "source": "host,5.56.0.1", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "ip"}, {"count": false, "log": false, "seq_id": 32, "destination": "host,5.55.0.1", "source": "host,5.57.0.1", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "icmp"}, {"count": false, "urg": false, "log": true, "source": "host,5.58.0.1", "ack": false, "seq_id": 33, "destination": "host,5.55.0.1", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "fin": false, "protocol_type": "tcp"}, {"count": false, "urg": false, "log": false, "source": "1.1.1.3/1.1.1.3", "ack": false, "seq_id": 40, "destination": "1.1.1.3/1.1.1.3", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.4/1.1.1.4", "ack": false, "seq_id": 50, "destination": "1.1.1.4/1.1.1.4", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.5/1.1.1.5", "ack": false, "seq_id": 60, "destination": "1.1.1.5/1.1.1.5", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.6/1.1.1.6", "ack": false, "seq_id": 70, "destination": "1.1.1.6/1.1.1.6", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.7/1.1.1.7", "ack": false, "seq_id": 80, "destination": "1.1.1.7/1.1.1.7", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.8/1.1.1.8", "ack": false, "seq_id": 90, "destination": "1.1.1.8/1.1.1.8", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.9/1.1.1.9", "ack": false, "seq_id": 100, "destination": "1.1.1.9/1.1.1.9", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.10/1.1.1.10", "ack": false, "seq_id": 110, "destination": "1.1.1.10/1.1.1.10", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"count": false, "urg": false, "log": false, "source": "1.1.1.11/1.1.1.11", "ack": false, "seq_id": 120, "destination": "1.1.1.11/1.1.1.11", "sync": false, "rst": false, "push": false, "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "tcp", "fin": false}, {"sync": false, "copy_sflow": false, "mirror": false, "action": "permit", "log": false, "seq_id": 130, "destination": "any eq ftp-data", "source": "1.1.1.12/1.1.1.12 range time talk", "fin": false, "push": false, "rst": false, "protocol_type": "tcp", "count": false, "urg": false, "ack": false}, {"count": false, "log": false, "seq_id": 140, "destination": "1.1.1.1/0.0.0.0", "source": "any neq tftp", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}, {"count": false, "log": false, "source": "any neq bootpc", "seq_id": 150, "destination": "any eq bootpc", "copy_sflow": false, "mirror": false, "action": "permit", "protocol_type": "udp"}]'
  stderr: 'st2.actions.python.GetAclRules: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.restproto)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.passwd)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.enablepass)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.ostype)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpver)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpport)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpv2c)
    st2.actions.python.GetAclRules: INFO     Getting rules for ACL new_ipv4_acl2
    '
  stdout: ''

SLX
------
(network_essentials) svivek@svivek-VirtualBox:~/Defects$ st2 run network_essentials.get_acl_rules mgmt_ip=10.18.124.15 acl_name=new_ipv4_acl2
.........
id: 5b314d25e3c93b496ab4ee5b
status: succeeded
parameters:
  acl_name: new_ipv4_acl2
  mgmt_ip: 10.18.124.15
result:
  exit_code: 0
  result: '[{"count": "False", "log": "False", "seq_id": "5", "destination": "5.55.0.0/0.0.255.255", "source": "4.44.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}, {"count": "False", "log": "False", "seq_id": "10", "destination": "5.55.0.0/0.0.255.255", "source": "4.44.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "ip"}, {"count": "False", "log": "False", "seq_id": "11", "destination": "5.55.0.0/0.0.255.255", "source": "4.45.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "icmp"}, {"count": "False", "log": "False", "seq_id": "12", "destination": "5.55.0.0/0.0.255.255", "source": "4.46.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "100"}, {"count": "False", "urg": "False", "log": "True", "source": "4.47.0.0/0.0.255.255", "ack": "False", "seq_id": "13", "destination": "5.55.0.0/0.0.255.255", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "log": "True", "seq_id": "14", "destination": "5.55.0.0/0.0.255.255", "source": "4.48.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}, {"count": "False", "log": "True", "seq_id": "15", "destination": "5.56.0.0/0.0.255.255", "source": "4.48.0.0/0.0.255.255", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}, {"count": "False", "log": "False", "seq_id": "20", "destination": "host,6.55.0.1", "source": "host,5.55.0.1", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}, {"count": "False", "log": "False", "seq_id": "31", "destination": "host,5.55.0.1", "source": "host,5.56.0.1", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "ip"}, {"count": "False", "log": "False", "seq_id": "32", "destination": "host,5.55.0.1", "source": "host,5.57.0.1", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "icmp"}, {"count": "False", "urg": "False", "log": "True", "source": "host,5.58.0.1", "ack": "False", "seq_id": "33", "destination": "host,5.55.0.1", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "fin": "False", "protocol_type": "tcp"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.3/1.1.1.3", "ack": "False", "seq_id": "40", "destination": "1.1.1.3/1.1.1.3", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.4/1.1.1.4", "ack": "False", "seq_id": "50", "destination": "1.1.1.4/1.1.1.4", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.5/1.1.1.5", "ack": "False", "seq_id": "60", "destination": "1.1.1.5/1.1.1.5", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.6/1.1.1.6", "ack": "False", "seq_id": "70", "destination": "1.1.1.6/1.1.1.6", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.7/1.1.1.7", "ack": "False", "seq_id": "80", "destination": "1.1.1.7/1.1.1.7", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.8/1.1.1.8", "ack": "False", "seq_id": "90", "destination": "1.1.1.8/1.1.1.8", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.9/1.1.1.9", "ack": "False", "seq_id": "100", "destination": "1.1.1.9/1.1.1.9", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.10/1.1.1.10", "ack": "False", "seq_id": "110", "destination": "1.1.1.10/1.1.1.10", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"count": "False", "urg": "False", "log": "False", "source": "1.1.1.11/1.1.1.11", "ack": "False", "seq_id": "120", "destination": "1.1.1.11/1.1.1.11", "sync": "False", "rst": "False", "push": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "tcp", "fin": "False"}, {"sync": "False", "copy_sflow": "False", "mirror": "False", "action": "permit", "log": "False", "seq_id": "130", "destination": "any eq ftp-data", "source": "1.1.1.12/1.1.1.12 range time talk", "fin": "False", "push": "False", "rst": "False", "protocol_type": "tcp", "count": "False", "urg": "False", "ack": "False"}, {"count": "False", "log": "False", "seq_id": "140", "destination": "1.1.1.1/0.0.0.0", "source": "any neq tftp", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}, {"count": "False", "log": "False", "source": "any neq bootpc", "seq_id": "150", "destination": "any eq bootpc", "copy_sflow": "False", "mirror": "False", "action": "permit", "protocol_type": "udp"}]'
  stderr: 'st2.actions.python.GetAclRules: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.restproto)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.passwd)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.enablepass)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.ostype)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpver)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpport)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.18.124.15.snmpv2c)
    st2.actions.python.GetAclRules: INFO     Getting rules for ACL new_ipv4_acl2
    '
  stdout: ''

MLX
------
(network_essentials) svivek@svivek-VirtualBox:~/Defects$ st2 run network_essentials.get_acl_rules mgmt_ip=10.37.73.148 acl_name=abc
....
id: 5b314d64e3c93b496ab4ee5e
status: succeeded
parameters:
  acl_name: abc
  mgmt_ip: 10.37.73.148
result:
  exit_code: 0
  result: '[{"action": "permit", "seq_id": "10", "destination": "any range ftp-data 32", "protocol_type": "udp", "source": "3.2.1.0/0.0.0.255 eq ftp-data"}, {"priority_force": "3", "fragment": "True", "seq_id": "20", "destination": "any", "mirror": "True", "suppress_rpf_drop": "true", "source": "any", "tos": "normal", "action": "permit", "protocol_type": "udp"}, {"priority_force": "3", "precedence": "flash", "fragment": "True", "seq_id": "30", "destination": "any", "mirror": "True", "suppress_rpf_drop": "true", "source": "any", "tos": "normal", "action": "permit", "protocol_type": "udp"}, {"priority_force": "3", "precedence": "flash", "fragment": "True", "seq_id": "40", "destination": "any", "suppress_rpf_drop": "true", "source": "any", "dscp_marking": "3", "copy_sflow": "True", "tos": "normal", "action": "permit", "protocol_type": "udp"}, {"priority_force": "3", "option": "extended-security", "precedence": "flash", "fragment": "True", "seq_id": "50", "destination": "any", "suppress_rpf_drop": "true", "dscp": "4", "source": "any", "dscp_marking": "3", "copy_sflow": "True", "tos": "min-delay", "action": "permit", "protocol_type": "udp"}, {"seq_id": "60", "destination": "any", "source": "any", "vlan_id": "23", "action": "permit", "protocol_type": "tcp"}, {"tcp_operator": "established syn", "seq_id": "70", "destination": "any", "source": "any", "action": "permit", "protocol_type": "tcp"}, {"seq_id": "80", "destination": "any", "source": "1.1.1.0/0.0.0.255", "action": "permit", "icmp_filter": "host-redirect", "protocol_type": "icmp"}, {"seq_id": "90", "destination": "any eq 30", "source": "any", "vlan_id": "555", "action": "permit", "protocol_type": "tcp"}, {"tcp_operator": "established syn", "seq_id": "100", "destination": "any", "source": "6.6.0.0/0.0.255.255 range ftp ssh", "vlan_id": "666", "action": "permit", "protocol_type": "tcp"}, {"tcp_operator": "established syn", "seq_id": "110", "destination": "7.7.7.0/0.0.0.255", "source": "6.6.0.0/0.0.255.255 range ftp ssh", "vlan_id": "777", "tos": "normal", "action": "permit", "protocol_type": "tcp"}, {"tcp_operator": "established syn", "log": "True", "seq_id": "120", "destination": "7.7.7.0/0.0.0.255", "suppress_rpf_drop": "true", "source": "6.6.0.0/0.0.255.255 range ftp ssh", "vlan_id": "777", "tos": "normal", "action": "permit", "protocol_type": "tcp"}, {"action": "permit", "seq_id": "300", "destination": "any", "protocol_type": "ggp", "source": "any"}]'
  stderr: 'st2.actions.python.GetAclRules: DEBUG    Creating new Client object.
    No handlers could be found for logger "st2.st2common.util.api"
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.restproto)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.user)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.passwd)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.enablepass)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.ostype)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.snmpver)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.snmpport)
    st2.actions.python.GetAclRules: DEBUG    Retrieving value from the datastore (name=switch.10.37.73.148.snmpv2c)
    st2.actions.python.GetAclRules: INFO     Getting rules for ACL abc
    '
  stdout: ''

